### PR TITLE
Respect runtime setting when creating new graph

### DIFF
--- a/components/CreateGraph.coffee
+++ b/components/CreateGraph.coffee
@@ -3,19 +3,27 @@ noflo = require 'noflo'
 class CreateGraph extends noflo.Component
   constructor: ->
     @baseDir = ''
+    @runtime = 'html'
     @inPorts =
       name: new noflo.Port 'string'
       basedir: new noflo.Port 'string'
+      runtime: new noflo.Port 'string'
     @outPorts =
       out: new noflo.Port 'object'
 
     @inPorts.name.on 'data', (name) =>
       graph = new noflo.Graph name
       graph.baseDir = @baseDir
+      if graph.properties.environment
+        graph.properties.environment.runtime = @runtime
+      else
+        graph.properties.environment =
+            runtime: @runtime
       @outPorts.out.send graph
     @inPorts.name.on 'disconnect', =>
       @outPorts.out.disconnect()
 
     @inPorts.basedir.on 'data', (@baseDir) =>
+    @inPorts.runtime.on 'data', (@runtime) =>
 
 exports.getComponent = -> new CreateGraph

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           </label>
           <label>
             Type
-            <select name="type">
+            <select name="type" id="runtime">
               <option value="html">Browser</option>
               <option value="websocket">Node.js</option>
             </select>
@@ -125,7 +125,17 @@
       GetNameInput ELEMENT -> DATA HoldInput(core/Kick)
       HoldInput OUT -> IN GetName(objects/GetObjectKey)
       'value' -> KEY GetName
-      ListenClick CLICK -> IN HoldInput
+
+      '#runtime' -> DATA RuntimeInputId(core/Kick)
+      SplitNew OUT -> IN RuntimeInputId
+      RuntimeInputId OUT -> SELECTOR GetRuntimeSelect(dom/GetElement)
+      GetRuntimeSelect ELEMENT -> DATA HoldRuntime(core/Kick)
+      HoldRuntime OUT -> IN GetRuntime(objects/GetObjectKey)
+      'value' -> KEY GetRuntime
+
+      ListenClick CLICK -> IN SplitClick(core/Split)
+      SplitClick OUT -> IN HoldRuntime
+      SplitClick OUT -> IN HoldInput
 
       # ## New project view
       '#new-template' -> TEMPLATE NewProjectView(ui/CreateProjectView)
@@ -136,7 +146,9 @@
       SaveProject DONE -> IN ShowSaved(core/Output)
 
       # Create graph and save
+      GetRuntime OUT -> RUNTIME CreateGraph
       GetName OUT -> IN SplitName(core/Split) OUT -> NAME CreateGraph
+
       CreateGraph OUT -> IN NewToJson(strings/Jsonify)
       SplitName OUT -> DATA SendNewKey(core/Kick)
       SendNewKey OUT -> KEY StoreNew(localstorage/SetItem)


### PR DESCRIPTION
The UI element was introduced in 3f0bc647978173383a7b26ae0995411f65311b02
and the logic changed, but not used. Not possible to create new sketches
for WebSocket based runtimes for that reason.

I saw just now that there has been some movement in this area this in the-graph branch... But here this is in case you want it :)
