### PR TITLE
Fix GenerateId giving the random function itself instead of result

### DIFF
--- a/components/GenerateId.coffee
+++ b/components/GenerateId.coffee
@@ -8,7 +8,7 @@ class GenerateId extends noflo.Component
       out: new noflo.Port 'string'
 
     @inPorts.start.on 'data', (data) =>
-      id = @randomString
+      id = @randomString()
       id = data.id if data.id
       @outPorts.out.send id
       @outPorts.out.disconnect()


### PR DESCRIPTION
Caused new sketch/project to fail to load, as the identifier was bogus.
Introduced in b68a2e7e4813e38ce6ca3175b8d128eb56fda724
