### PR TITLE
Send monitored edges before initializing the network

### DIFF
--- a/elements/noflo-runtime.html
+++ b/elements/noflo-runtime.html
@@ -164,7 +164,6 @@
         this.runtime.on('execution', function (status) {
           if (status.running) {
             this.execution.running = true;
-            this.sendEdges();
           } else {
             this.execution.running = false;
           }
@@ -194,6 +193,7 @@
         event.preventDefault();
         this.requestNotificationPermission();
         if (this.card) {
+          this.sendEdges();
           this.runtime.start();
           return;
         }


### PR DESCRIPTION
When some edges are selected in the UI, we want to monitor the IPs passing through then at the very beginning of the network's life.
Therefor we need to send monitored edges before initializing the network (which propagate initials into it).
