### PR TITLE
Fix unable to open newly created graphs

### DIFF
--- a/elements/noflo-new-graph.html
+++ b/elements/noflo-new-graph.html
@@ -38,6 +38,7 @@
         var noflo = require('noflo');
         var graph = new noflo.Graph(this.name);
         graph.setProperties({
+          id: graph.name.replace(' ', '_'),
           project: this.project,
           environment: {
             type: this.type


### PR DESCRIPTION
Without this change the 'data-id' attribute of the list entry is empty,
as graph.properties.id is not set. It could be this should be
fixed in GenerateId instead?
