### PR TITLE
node-inspector: don't send string when the port expects numbers

### DIFF
--- a/elements/noflo-node-inspector.html
+++ b/elements/noflo-node-inspector.html
@@ -344,6 +344,8 @@
             break;
           case 'boolean':
             return input.checked;
+        case 'number':
+            return parseFloat(input.value);
           default:
             return input.value;
         }


### PR DESCRIPTION
Fixes https://github.com/noflo/noflo-ui/issues/115
