### PR TITLE
Add jonnor/noflo-cad to HTML preview runtime

### DIFF
--- a/preview/component.json
+++ b/preview/component.json
@@ -28,7 +28,8 @@
     "noflo/noflo-finitedomain": "*",
     "d4tocchini/noflo-draggabilly": "*",
     "forresto/noflo-gum": "*",
-    "forresto/noflo-seriously": "*"
+    "forresto/noflo-seriously": "*",
+    "jonnor/noflo-cad": "*"
   },
   "json": [
     "component.json"


### PR DESCRIPTION
Allow user to make parametric 3d models directly in the browser,
with live preview.
