### PR TITLE
bump grunt-contrib-compress dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-coffeelint": "~0.0.6",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-compress": "~0.5.2",
+    "grunt-contrib-compress": "~0.9.1",
     "grunt-contrib-connect": "^0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",


### PR DESCRIPTION
grunt build is crashing with :

```
Running "compress:app" (compress) task

Done, without errors.

Error: Process exited before Archiver could finish emitting data
  at [object Object].<anonymous> (/noflo-ui/node_modules/grunt-contrib-compress/node_modules/archiver/lib/archiver/core.js:79:13)
  at process.g (events.js:180:16)
  at process.EventEmitter.emit (events.js:117:20)
  at process.exit (node.js:707:17)
  at tryToExit (/noflo-ui/node_modules/grunt/node_modules/exit/lib/exit.js:17:15)
  at Object.exit (/noflo-ui/node_modules/grunt/node_modules/exit/lib/exit.js:34:3)
  at Object.task.options.done (/noflo-ui/node_modules/grunt/lib/grunt.js:154:14)
  at Task.<anonymous> (/noflo-ui/node_modules/grunt/lib/util/task.js:280:25)
  at /noflo-ui/node_modules/grunt/lib/util/task.js:227:11
  at process._tickCallback (node.js:415:13)
```

It turns out it has been fixed upstream :

https://github.com/gruntjs/grunt-contrib-compress/issues/80

Available in grunt-contrib-compress 0.9.1
