### PR TITLE
noflo-node-inspector: fix attached() method not being called by Polymer

### DIFF
--- a/elements/noflo-node-inspector.html
+++ b/elements/noflo-node-inspector.html
@@ -359,7 +359,7 @@
       component: null,
       graph: null,
       inports: [],
-      attached: function () {
+      nodeChanged: function() {
         this.updatePorts();
         this.label = this.node.metadata.label;
       },


### PR DESCRIPTION
Should fix https://github.com/noflo/noflo-ui/issues/314
