### PR TITLE
context: fix access to component code in live mode

### DIFF
--- a/elements/noflo-context.html
+++ b/elements/noflo-context.html
@@ -318,9 +318,6 @@
       },
       canGetSource: function (component) {
         var componentParts = component.split('/');
-        if (!this.project) {
-          return false;
-        }
 
         if (componentParts.length > 1 && this.project && this.libraryMatch(componentParts.shift(), this.project)) {
           // Local component, see if it is available


### PR DESCRIPTION
There is no project in live mode, the rest of the function had the right assumptions.
