### PR TITLE
[docs] installation requires admin rights on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This will provide you with all the needed development dependencies. Now you can 
 
     $ grunt build
 
+You have to run this command as an administrator on Windows.
+
 If you prefer, you can also start a watcher process that will do a rebuild whenever one of the files changes:
 
     $ grunt watch


### PR DESCRIPTION
I got the following warning when I ran `grunt build` without administrator privileges:
```
...
Warning: EPERM, symlink 'P:\noflo-ui\components\noflo-noflo-polymer\noflo-polymer\noflo-polymer.html' Use --force to con
tinue.

Aborted due to warnings.
```

Running as an admin (reproducibly) resolved this problem.
