### PR TITLE
Recursively delete preview/components when nuking

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -53,7 +53,7 @@ module.exports = ->
       dependencies: [
         'bower_components'
         'components/*/'
-        'preview/components'
+        'preview/components/*/'
       ]
       dist: [
         'dist'


### PR DESCRIPTION
I got the following error when I ran `grunt rebuild` (i.e. `grunt nuke` + `grunt build`):

````
PS P:\noflo-ui> grunt rebuild
Running "clean:build" (clean) task
>> 0 paths cleaned.

Running "clean:dependencies" (clean) task
ERROR
Warning: Unable to delete "preview/components" file (ENOTEMPTY, directory not empty 'P:\noflo-ui\preview\components\nofl
o-noflo'). Use --force to continue.

Aborted due to warnings.
```

OS: Windows 8.1 Pro 64-bit