### PR TITLE
Updated grunt-string-replace to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-noflo-manifest": "0.1.11",
     "grunt-phonegap-build": "0.0.8",
     "grunt-saucelabs": "8.6.1",
-    "grunt-string-replace": "0.2.8",
+    "grunt-string-replace": "1.2.0",
     "grunt-vulcanize": "0.4.2",
     "grunt-zip": "0.13.0"
   },


### PR DESCRIPTION
:rocket:

grunt-string-replace just published version 1.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 17 commits (ahead by 17, behind by 0).

- [9f49dbe](https://github.com/erickrdch/grunt-string-replace/commit/9f49dbead5dfee08dcaed6ee7579c8b1a2146594): 1.2.0
- [877784f](https://github.com/erickrdch/grunt-string-replace/commit/877784fb4cf0ba73b5b55d330752a8e04557a75a): Add `saveUnchanged`; Add iojs to Travis CI
- [4d4994e](https://github.com/erickrdch/grunt-string-replace/commit/4d4994e5abc87876bae9d3e90c781b7e668ddee3): Merge pull request #30 from sercaneraslan/master
- [5882c1c](https://github.com/erickrdch/grunt-string-replace/commit/5882c1c4fa0793735e654e4b66810445379f30d2): 1.1.1
- [d7b4b98](https://github.com/erickrdch/grunt-string-replace/commit/d7b4b9839ca3156f230bad558bb9d254bd16e2b1): add v0.12 to travis ci
- [5f37763](https://github.com/erickrdch/grunt-string-replace/commit/5f37763da38d0c8d7e33d602ff7ca17b62996d4d): 1.1.0
- [cfd1b3c](https://github.com/erickrdch/grunt-string-replace/commit/cfd1b3c35eaa830c35b935a558ca7191d0d99ed4): 1.1.0
- [b2d1829](https://github.com/erickrdch/grunt-string-replace/commit/b2d1829a0e6a456341361baff8ba2cb1ab1f5f2c): string-replace object is closed
- [be13f9c](https://github.com/erickrdch/grunt-string-replace/commit/be13f9ccab67dad8725e7fcb5249039859171cd9): 1.0.0
- [e081f87](https://github.com/erickrdch/grunt-string-replace/commit/e081f8702dc73feca73fbf22a3c03fec395b264c): Updates to README.md
- [323f438](https://github.com/erickrdch/grunt-string-replace/commit/323f43835fbc1c029b4e0ada8787987423973ef6): Updating requirements
- [3e5257d](https://github.com/erickrdch/grunt-string-replace/commit/3e5257da1ae5a717a6e2a3ff13dc92ac6fe3be8d): Update badges to SVG versions
- [985b0ab](https://github.com/erickrdch/grunt-string-replace/commit/985b0ab9be7ead3003b2cb7dd9a513c2e61980ce): Merge pull request #24 from erickrdch/1.0.0
- [836f111](https://github.com/erickrdch/grunt-string-replace/commit/836f11111dfcbe3a84969a0b3c7d9408af512051): latest dependencies require a recent npm version
- [2383d26](https://github.com/erickrdch/grunt-string-replace/commit/2383d26e0cd0b550dd0e0cc9f3bf99ac1f330408): Trying to get Travis working again


There are 17 commits in total. See the [full diff](https://github.com/erickrdch/grunt-string-replace/compare/dab1758cbd18b99c88da960ef0707a78871113da...9f49dbead5dfee08dcaed6ee7579c8b1a2146594).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>