### PR TITLE
Safari 9 support

### DIFF
--- a/index.dist.html
+++ b/index.dist.html
@@ -26,7 +26,13 @@
     <script src="bower_components/react/react-with-addons.js"></script>
     <script src="bower_components/ease-djdeath/index.js"></script>
     <script src="bower_components/react.animate-djdeath/react.animate.js"></script>
-    <script src="browser/noflo-noflo-indexeddb/vendor/IndexedDBShim.min.js"></script>
+    <script src="node_modules/indexeddbshim/dist/indexeddbshim.min.js"></script>
+    <script>
+      if (navigator.userAgent.toLowerCase().indexOf('safari/') !== -1) {
+        console.log('Safari detected, replacing broken IndexedDB with shim');
+        window.shimIndexedDB.__useShim();
+      }
+    </script>
     <script src="bower_components/rtc/dist/rtc.js"></script>
     <script src="./browser/noflo-ui.js"></script>
 

--- a/index.dist.html
+++ b/index.dist.html
@@ -19,7 +19,7 @@
     <link rel="icon" sizes="192x192" href="app/$NOFLO_THEME-192.png">
     <link rel="icon" sizes="128x128" href="app/$NOFLO_THEME-128.png">
     <link rel="shortcut icon" href="$NOFLO_THEME.ico" />
-    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script src="node_modules/webcomponents.js/webcomponents.min.js"></script>
     <link rel="import" href="bower_components/polymer/polymer.html">
     <script src="bower_components/klayjs-noflo/klay-noflo.js"></script>
     <script src="bower_components/hammerjs/hammer.js"></script>

--- a/index.dist.html
+++ b/index.dist.html
@@ -28,7 +28,7 @@
     <script src="bower_components/react.animate-djdeath/react.animate.js"></script>
     <script src="node_modules/indexeddbshim/dist/indexeddbshim.min.js"></script>
     <script>
-      if (navigator.userAgent.toLowerCase().indexOf('safari/') !== -1) {
+      if (navigator.vendor && navigator.vendor.indexOf('Apple') !== -1) {
         console.log('Safari detected, replacing broken IndexedDB with shim');
         window.shimIndexedDB.__useShim();
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "indexeddbshim": "^2.2.1",
-    "webcomponents.js": "^0.7.18"
+    "webcomponents.js": "0.6.0"
   },
   "devDependencies": {
     "mocha": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     }
   ],
   "dependencies": {
+    "indexeddbshim": "^2.2.1",
     "webcomponents.js": "^0.7.18"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
       "url": "undefined/blob/master/LICENSE-MIT"
     }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "webcomponents.js": "^0.7.18"
+  },
   "devDependencies": {
     "mocha": "2.3.3",
     "chai": "1.10.0",


### PR DESCRIPTION
Fixes the following problems:

* The old web components polyfill is not compatible with Safari 9 (#521)
* Force IndexedDB Shim on Safari

However, these are not enough, as it seems that Polymer templating is not working. With these patches there are no errors but user sees the following:

<img width="1227" alt="screen shot 2015-12-01 at 21 40 09" src="https://cloud.githubusercontent.com/assets/3346/11515119/2886e00e-9874-11e5-900e-515677b75609.png">
