### PR TITLE
Receive graph events from runtime

### DIFF
--- a/components/CollectRemoteNodes.coffee
+++ b/components/CollectRemoteNodes.coffee
@@ -16,10 +16,21 @@ exports.getComponent = ->
         return
       c.context = payload
 
-      if 'component:getsource' in payload.runtime.definition.capabilities
+      if 'graph:getgraph' in payload.runtime.definition.capabilities
+        graphName = payload.runtime.definition.graph
+        payload.graphs.push new noflo.Graph graphName, caseSensitive: true
+        payload.state = 'ok'
+
+        c.outPorts.context.send payload
+        c.outPorts.context.disconnect()
+
+        payload.runtime.sendGraph 'getgraph', id: graphName
+
+      else if 'component:getsource' in payload.runtime.definition.capabilities
         c.outPorts.runtime.send c.context.runtime
         c.outPorts.runtime.disconnect()
         c.outPorts.component.send c.context.remote.shift()
+
       else
         graphName = payload.runtime.definition.graph
         payload.graphs.push new noflo.Graph graphName, caseSensitive: true

--- a/components/CollectRemoteNodes.coffee
+++ b/components/CollectRemoteNodes.coffee
@@ -15,9 +15,17 @@ exports.getComponent = ->
         c.error new Error 'No runtime connection for getting remote nodes'
         return
       c.context = payload
-      c.outPorts.runtime.send c.context.runtime
-      c.outPorts.runtime.disconnect()
-      c.outPorts.component.send c.context.remote.shift()
+
+      if 'component:getsource' in payload.runtime.definition.capabilities
+        c.outPorts.runtime.send c.context.runtime
+        c.outPorts.runtime.disconnect()
+        c.outPorts.component.send c.context.remote.shift()
+      else
+        graphName = payload.runtime.definition.graph
+        payload.graphs.push new noflo.Graph graphName, caseSensitive: true
+        c.outPorts.context.send payload
+        c.outPorts.context.disconnect()
+
   c.inPorts.add 'component',
     datatype: 'object'
     process: (event, payload) ->

--- a/components/UpdateGraph.coffee
+++ b/components/UpdateGraph.coffee
@@ -38,6 +38,13 @@ class UpdateGraph extends noflo.Component
       process: (event, payload) =>
         graph = @graph
 
+        if (
+          event is 'data' and
+          payload.command is 'clear' and
+          payload.id is graph.name
+        )
+          noflo.resetGraph graph
+
         if event is 'data' and payload.payload?.graph is graph.name
           command = payload.command
 

--- a/components/UpdateGraph.coffee
+++ b/components/UpdateGraph.coffee
@@ -1,0 +1,199 @@
+noflo = require 'noflo'
+_ = require 'underscore'
+
+getInitial = (graph, node, port) ->
+  for initial in graph.initializers
+    if initial.to.node is node and initial.to.port is port
+      return initial
+
+  return null
+
+getGroup = (graph, name) ->
+  for group in graph.groups
+    if group.name is name
+      return group
+
+  return null
+
+class UpdateGraph extends noflo.Component
+  graph: null
+
+  constructor: ->
+    @inPorts = new noflo.InPorts
+
+    @inPorts.add 'graph',
+      datatype: 'object'
+      process: (event, payload) =>
+        if event is 'data'
+          @graph = payload
+
+    @inPorts.add 'event',
+      datatype: 'object'
+      process: (event, payload) =>
+        graph = @graph
+
+        if event is 'data' and payload.payload?.graph is graph.name
+          command = payload.command
+
+          switch command
+            when 'addnode'
+              id = payload.payload.id
+              component = payload.payload.component
+              metadata = payload.payload.metadata
+
+              oldNode = graph.getNode id
+
+              unless oldNode
+                graph.addNode id, component, metadata
+
+            when 'removenode'
+              id = payload.payload.id
+
+              graph.removeNode id
+
+            when 'changenode'
+              id = payload.payload.id
+              metadata = payload.payload.metadata
+
+              oldNode = graph.getNode id
+
+              if oldNode and not _.isEqual(oldNode.metadata, metadata)
+                graph.setNodeMetadata id, metadata
+
+            when 'addedge'
+              srcNode = payload.payload.src.node
+              srcPort = payload.payload.src.port
+              srcIndex = payload.payload.src.index
+
+              targetNode = payload.payload.tgt.node
+              targetPort = payload.payload.tgt.port
+              targetIndex = payload.payload.tgt.index
+
+              oldEdge = graph.getEdge srcNode, srcPort, targetNode, targetPort
+
+              unless oldEdge
+                graph.addEdgeIndex srcNode, srcPort, srcIndex,
+                  targetNode, targetPort, targetIndex
+
+            when 'removeedge'
+              srcNode = payload.payload.src.node
+              srcPort = payload.payload.src.port
+
+              targetNode = payload.payload.tgt.node
+              targetPort = payload.payload.tgt.port
+
+              oldEdge = graph.getEdge srcNode, srcPort, targetNode, targetPort
+
+              if oldEdge
+                graph.removeEdge srcNode, srcPort, targetNode, targetPort
+
+            when 'changeedge'
+              srcNode = payload.payload.src.node
+              srcPort = payload.payload.src.port
+
+              targetNode = payload.payload.tgt.node
+              targetPort = payload.payload.tgt.port
+
+              metadata = payload.payload.metadata
+
+              oldEdge = graph.getEdge srcNode, srcPort, targetNode, targetPort
+
+              if oldEdge and not _.isEqual(oldEdge.metadata, metadata)
+                graph.setEdgeMetadata srcNode, srcPort, targetNode, targetPort, metadata
+
+            when 'addinitial'
+              data = payload.payload.src.data
+              node = payload.payload.tgt.node
+              port = payload.payload.tgt.port
+              index = payload.payload.tgt.index
+              metadata = payload.payload.metadata
+
+              oldInitial = getInitial graph, node, port
+
+              unless oldInitial
+                graph.addInitialIndex data, node, port, index, metadata
+
+            when 'removeinitial'
+              node = payload.payload.tgt.node
+              port = payload.payload.tgt.port
+
+              oldInitial = getInitial graph, node, port
+
+              if oldInitial
+                graph.removeInitial node, port
+
+            when 'addinport'
+              publicPort = payload.payload.public
+              node = payload.payload.node
+              port = payload.payload.port
+              metadata = payload.payload.metadata
+
+              graph.addInport publicPort, node, port, metadata
+
+            when 'removeinport'
+              publicPort = payload.payload.public
+              graph.removeInport publicPort
+
+            when 'renameinport'
+              from = payload.payload.from
+              to = payload.payload.to
+
+              graph.renameInport from, to
+
+            when 'addoutport'
+              publicPort = payload.payload.public
+              node = payload.payload.node
+              port = payload.payload.port
+              metadata = payload.payload.metadata
+
+              graph.addOutport publicPort, node, port, metadata
+
+            when 'removeoutport'
+              publicPort = payload.payload.public
+              graph.removeOutport publicPort
+
+            when 'renameoutport'
+              from = payload.payload.from
+              to = payload.payload.to
+
+              graph.renameOutport from, to
+
+            when 'addgroup'
+              name = payload.payload.name
+              nodes = payload.payload.nodes
+              metadata = payload.payload.metadata
+
+              oldGroup = getGroup graph, name
+
+              unless oldGroup
+                graph.addGroup name, nodes, metadata
+
+            when 'removegroup'
+              name = payload.payload.name
+
+              oldGroup = getGroup graph, name
+
+              if oldGroup
+                graph.removeGroup name
+
+            when 'renamegroup'
+              from = payload.payload.from
+              to = payload.payload.to
+
+              oldGroup = getGroup graph, from
+
+              if oldGroup
+                graph.renameGroup from, to
+
+            when 'changegroup'
+              name = payload.payload.name
+              metadata = payload.payload.metadata
+
+              oldGroup = getGroup graph, name
+
+              if oldGroup and not _.isEqual(oldGroup.metadata, metadata)
+                graph.setGroupMetadata name, metadata
+
+    @outPorts = new noflo.OutPorts
+
+exports.getComponent = -> new UpdateGraph

--- a/components/UpdateGraph.coffee
+++ b/components/UpdateGraph.coffee
@@ -1,6 +1,12 @@
 noflo = require 'noflo'
 _ = require 'underscore'
 
+getInport = (graph, publicPort) ->
+  graph.inports[publicPort]
+
+getOutport = (graph, publicPort) ->
+  graph.outports[publicPort]
+
 getInitial = (graph, node, port) ->
   for initial in graph.initializers
     if initial.to.node is node and initial.to.port is port
@@ -49,7 +55,10 @@ class UpdateGraph extends noflo.Component
             when 'removenode'
               id = payload.payload.id
 
-              graph.removeNode id
+              oldNode = graph.getNode id
+
+              if oldNode
+                graph.removeNode id
 
             when 'changenode'
               id = payload.payload.id
@@ -128,7 +137,8 @@ class UpdateGraph extends noflo.Component
               port = payload.payload.port
               metadata = payload.payload.metadata
 
-              graph.addInport publicPort, node, port, metadata
+              unless getInport graph, publicPort
+                graph.addInport publicPort, node, port, metadata
 
             when 'removeinport'
               publicPort = payload.payload.public
@@ -138,7 +148,10 @@ class UpdateGraph extends noflo.Component
               from = payload.payload.from
               to = payload.payload.to
 
-              graph.renameInport from, to
+              renamed = getInport graph, to
+
+              unless renamed
+                graph.renameInport from, to
 
             when 'addoutport'
               publicPort = payload.payload.public
@@ -146,7 +159,8 @@ class UpdateGraph extends noflo.Component
               port = payload.payload.port
               metadata = payload.payload.metadata
 
-              graph.addOutport publicPort, node, port, metadata
+              unless getOutport graph, publicPort
+                graph.addOutport publicPort, node, port, metadata
 
             when 'removeoutport'
               publicPort = payload.payload.public
@@ -155,6 +169,11 @@ class UpdateGraph extends noflo.Component
             when 'renameoutport'
               from = payload.payload.from
               to = payload.payload.to
+
+              renamed = getInport graph, to
+
+              unless renamed
+                graph.renameInport from, to
 
               graph.renameOutport from, to
 

--- a/components/UpdateGraph.coffee
+++ b/components/UpdateGraph.coffee
@@ -43,7 +43,7 @@ class UpdateGraph extends noflo.Component
           payload.command is 'clear' and
           payload.id is graph.name
         )
-          noflo.resetGraph graph
+          noflo.graph.mergeResolveTheirs graph, (new noflo.graph.Graph)
 
         if event is 'data' and payload.payload?.graph is graph.name
           command = payload.command
@@ -118,7 +118,7 @@ class UpdateGraph extends noflo.Component
                 graph.setEdgeMetadata srcNode, srcPort, targetNode, targetPort, metadata
 
             when 'addinitial'
-              data = payload.payload.src.data
+              data = payload.payload.data
               node = payload.payload.tgt.node
               port = payload.payload.tgt.port
               index = payload.payload.tgt.index

--- a/elements/noflo-runtime.html
+++ b/elements/noflo-runtime.html
@@ -190,6 +190,7 @@
         }
         if (this.runtime && this.graph) {
           this.runtime.setMain(this.graph);
+          this.runtimeChanged();
         }
       },
       runtimeChanged: function () {

--- a/graphs/RuntimeStorage.fbp
+++ b/graphs/RuntimeStorage.fbp
@@ -34,6 +34,12 @@ DirectRuntime CONTEXT -> IN MergeContextPreSubscribe
 # Get components list when connecting to new runtime
 ProjectRuntime RUNTIME -> RUNTIME ListComponents(runtime/ListComponents)
 DirectRuntime RUNTIME -> RUNTIME ListComponents
+
+ProjectRuntime RUNTIME -> RUNTIME ListenRuntime(runtime/ListenRuntime)
+DirectRuntime RUNTIME -> RUNTIME ListenRuntime
+
+ListenRuntime CONNECTED -> IN Drop(core/Drop)
+
 ListComponents OUT -> IN UpdateLibrary(ui/UpdateComponentLibrary)
 ProjectRuntime RUNTIME -> RUNTIME UpdateLibrary
 DirectRuntime RUNTIME -> RUNTIME UpdateLibrary
@@ -44,6 +50,10 @@ ListComponents ERROR -> IN ShowErrors
 MergeContextPreSubscribe OUT -> CONTEXT SubscribeGraph(ui/SubscribeGraph)
 SubscribeGraph RUNTIME -> RUNTIME SendGraph(runtime/SendGraphChanges)
 SubscribeGraph GRAPH -> GRAPH SendGraph
+
+SubscribeGraph GRAPH -> GRAPH UpdateGraph(ui/UpdateGraph)
+ListenRuntime GRAPH -> EVENT UpdateGraph
+
 SubscribeGraph OUT -> IN MergeContext(core/Merge)
 
 SubscribeGraph RUNTIME -> RUNTIME ListenNetwork(runtime/ListenNetwork)

--- a/spec/UpdateGraph.coffee
+++ b/spec/UpdateGraph.coffee
@@ -1,0 +1,608 @@
+noflo = require 'noflo'
+chai = require 'chai' unless chai
+_ = require 'underscore'
+
+UpdateGraph = require '../components/UpdateGraph.coffee'
+BaseRuntime = require '../components/flowbased-fbp-protocol-client/src/base.coffee'
+
+describe 'Update Graph', ->
+  component = null
+  graph = null
+  graphSocket = null
+  eventSocket = null
+
+  beforeEach ->
+    component = UpdateGraph.getComponent()
+    graph = new noflo.Graph 'graph1'
+
+    graphSocket = noflo.internalSocket.createSocket()
+    component.inPorts.graph.attach graphSocket
+
+    eventSocket = noflo.internalSocket.createSocket()
+    component.inPorts.event.attach eventSocket
+
+  describe 'instantiation', ->
+    it 'should have a "graph" inport', ->
+      chai.expect(component.inPorts.graph).to.be.an 'object'
+
+    it 'should have a "event" inport', ->
+      chai.expect(component.inPorts.event).to.be.an 'object'
+
+    it 'should attach graph', ->
+      graphSocket.send graph
+      chai.expect(component.graph).to.equal graph
+
+  describe 'graph events', ->
+    beforeEach ->
+      graphSocket.send graph
+
+    it 'should receive addnode events', ->
+      event =
+        protocol: 'graph'
+        command: 'addnode'
+        payload:
+          graph: 'graph1'
+          id: 'abcd'
+          component: 'core/Drop'
+          metadata:
+            label: 'Drop'
+            x: 1.0
+            y: 1.0
+
+      chai.expect(graph.nodes.length).to.equal 0
+      eventSocket.send event
+      chai.expect(graph.nodes.length).to.equal 1
+
+      node = graph.getNode event.payload.id
+      chai.expect(node.component).to.equal event.payload.component
+
+    it 'should receive removenode events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Drop'
+
+      event =
+        protocol: 'graph'
+        command: 'removenode'
+        payload:
+          graph: 'graph1'
+          id: 'abcd'
+
+      graph.addNode node.id, node.component, {}
+
+      chai.expect(graph.nodes.length).to.equal 1
+      eventSocket.send event
+      chai.expect(graph.nodes.length).to.equal 0
+
+    it 'should receive changenode events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Drop'
+
+      event =
+        protocol: 'graph'
+        command: 'changenode'
+        payload:
+          graph: 'graph1'
+          id: 'abcd'
+          metadata:
+            label: 'after'
+
+      graph.addNode node.id, node.component, label: 'before'
+
+      chai.expect(graph.nodes.length).to.equal 1
+
+      graphNode = graph.getNode node.id
+      chai.expect(graphNode.metadata.label).to.equal 'before'
+
+      eventSocket.send event
+      chai.expect(graphNode.metadata.label).to.equal 'after'
+
+    it 'should receive addedge events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      event =
+        protocol: 'graph'
+        command: 'addedge'
+        payload:
+          graph: 'graph1'
+          src:
+            node: 'abcd'
+            port: 'out'
+          tgt:
+            node: 'efgh'
+            port: 'in'
+
+      graph.addNode node1.id, node1.component, {}
+      graph.addNode node2.id, node2.component, {}
+
+      chai.expect(graph.edges.length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(graph.edges.length).to.equal 1
+
+      edge = graph.getEdge event.payload.src.node, event.payload.src.port,
+        event.payload.tgt.node, event.payload.tgt.port
+
+      chai.expect(edge).to.exist()
+
+    it 'should receive addedge events with index', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      event =
+        protocol: 'graph'
+        command: 'addedge'
+        payload:
+          graph: 'graph1'
+          src:
+            node: 'abcd'
+            port: 'out'
+            index: 0
+          tgt:
+            node: 'efgh'
+            port: 'in'
+            index: 1
+
+      graph.addNode node1.id, node1.component, {}
+      graph.addNode node2.id, node2.component, {}
+
+      chai.expect(graph.edges.length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(graph.edges.length).to.equal 1
+
+      edge = graph.getEdge event.payload.src.node, event.payload.src.port,
+        event.payload.tgt.node, event.payload.tgt.port
+
+      chai.expect(edge).to.exist()
+      chai.expect(edge.from.index).to.equal 0
+      chai.expect(edge.to.index).to.equal 1
+
+    it 'should receive removeedge events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      event =
+        protocol: 'graph'
+        command: 'removeedge'
+        payload:
+          graph: 'graph1'
+          src:
+            node: 'abcd'
+            port: 'out'
+          tgt:
+            node: 'efgh'
+            port: 'in'
+
+      graph.addNode node1.id, node1.component, {}
+      graph.addNode node2.id, node2.component, {}
+      graph.addEdge node1.id, event.payload.src.port,
+        node2.id, event.payload.tgt.port
+
+      chai.expect(graph.edges.length).to.equal 1
+
+      eventSocket.send event
+      chai.expect(graph.edges.length).to.equal 0
+
+    it 'should receive changeedge events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      event =
+        protocol: 'graph'
+        command: 'changeedge'
+        payload:
+          graph: 'graph1'
+          src:
+            node: 'abcd'
+            port: 'out'
+          tgt:
+            node: 'efgh'
+            port: 'in'
+          metadata:
+            label: 'after'
+
+      graph.addNode node1.id, node1.component, {}
+      graph.addNode node2.id, node2.component, {}
+      graph.addEdge node1.id, event.payload.src.port,
+        node2.id, event.payload.tgt.port, label: 'before'
+
+      chai.expect(graph.edges.length).to.equal 1
+      edge = graph.getEdge event.payload.src.node, event.payload.src.port,
+        event.payload.tgt.node, event.payload.tgt.port
+
+      chai.expect(edge.metadata.label).to.equal 'before'
+      eventSocket.send event
+
+      chai.expect(edge.metadata.label).to.equal 'after'
+
+    it 'should receive addinitial events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Drop'
+
+      event =
+        protocol: 'graph'
+        command: 'addinitial'
+        payload:
+          graph: 'graph1'
+          src:
+            data: 'hello'
+          tgt:
+            node: 'abcd'
+            port: 'in'
+
+      graph.addNode node.id, node.component, {}
+
+      chai.expect(graph.initializers.length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(graph.initializers.length).to.equal 1
+
+    it 'should receive addinitial events with index', ->
+      node =
+        id: 'abcd'
+        component: 'core/Drop'
+
+      event =
+        protocol: 'graph'
+        command: 'addinitial'
+        payload:
+          graph: 'graph1'
+          src:
+            data: 'hello'
+          tgt:
+            node: 'abcd'
+            port: 'in'
+            index: 0
+
+      graph.addNode node.id, node.component, {}
+      chai.expect(graph.initializers.length).to.equal 0
+
+      eventSocket.send event
+
+      chai.expect(graph.initializers.length).to.equal 1
+      chai.expect(graph.initializers[0].to.index).to.equal 0
+
+    it 'should receive removeinitial events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Drop'
+
+      initial =
+        data: 'hello'
+        node: 'abcd'
+        port: 'in'
+
+      event =
+        protocol: 'graph'
+        command: 'removeinitial'
+        payload:
+          graph: 'graph1'
+          tgt:
+            node: 'abcd'
+            port: 'in'
+
+      graph.addNode node.id, node.component, {}
+      graph.addInitial initial.data, initial.node, initial.port
+
+      chai.expect(graph.initializers.length).to.equal 1
+
+      eventSocket.send event
+      chai.expect(graph.initializers.length).to.equal 0
+
+    it 'should receive addinport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      event =
+        protocol: 'graph'
+        command: 'addinport'
+        payload:
+          graph: 'graph1'
+          public: 'hello'
+          node: 'abcd'
+          port: 'out'
+          metadata:
+            label: 'abc'
+
+      graph.addNode node.id, node.component, {}
+
+      chai.expect(_.keys(graph.inports).length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(_.keys(graph.inports).length).to.equal 1
+
+    it 'should receive removeinport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      inport =
+        public: 'hello'
+        node: 'abcd'
+        port: 'out'
+
+      event =
+        protocol: 'graph'
+        command: 'removeinport'
+        payload:
+          graph: 'graph1'
+          public: 'hello'
+
+      graph.addNode node.id, node.component, {}
+      graph.addInport inport.public, inport.node, inport.port
+
+      chai.expect(_.keys(graph.inports).length).to.equal 1
+
+      eventSocket.send event
+      chai.expect(_.keys(graph.inports).length).to.equal 0
+
+    it 'should receive renameinport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      inport =
+        public: 'hello'
+        node: 'abcd'
+        port: 'out'
+
+      event =
+        protocol: 'graph'
+        command: 'renameinport'
+        payload:
+          graph: 'graph1'
+          from: 'hello'
+          to: 'goodbye'
+
+      graph.addNode node.id, node.component, {}
+      graph.addInport inport.public, inport.node, inport.port
+
+      chai.expect(_.keys(graph.inports).length).to.equal 1
+      chai.expect(graph.inports[inport.public]).to.exist()
+      chai.expect(graph.inports[event.payload.to]).not.to.exist()
+
+      eventSocket.send event
+
+      chai.expect(_.keys(graph.inports).length).to.equal 1
+      chai.expect(graph.inports[inport.public]).not.to.exist()
+      chai.expect(graph.inports[event.payload.to]).to.exist()
+
+    it 'should receive addoutport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      event =
+        protocol: 'graph'
+        command: 'addoutport'
+        payload:
+          graph: 'graph1'
+          public: 'hello'
+          node: 'abcd'
+          port: 'out'
+          metadata:
+            label: 'abc'
+
+      graph.addNode node.id, node.component, {}
+
+      chai.expect(_.keys(graph.outports).length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(_.keys(graph.outports).length).to.equal 1
+
+    it 'should receive removeoutport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      outport =
+        public: 'hello'
+        node: 'abcd'
+        port: 'out'
+
+      event =
+        protocol: 'graph'
+        command: 'removeoutport'
+        payload:
+          graph: 'graph1'
+          public: 'hello'
+
+      graph.addNode node.id, node.component, {}
+      graph.addOutport outport.public, outport.node, outport.port
+
+      chai.expect(_.keys(graph.outports).length).to.equal 1
+
+      eventSocket.send event
+      chai.expect(_.keys(graph.outports).length).to.equal 0
+
+    it 'should receive renameoutport events', ->
+      node =
+        id: 'abcd'
+        component: 'core/Kick'
+
+      outport =
+        public: 'hello'
+        node: 'abcd'
+        port: 'out'
+
+      event =
+        protocol: 'graph'
+        command: 'renameoutport'
+        payload:
+          graph: 'graph1'
+          from: 'hello'
+          to: 'goodbye'
+
+      graph.addNode node.id, node.component, {}
+      graph.addOutport outport.public, outport.node, outport.port
+
+      chai.expect(_.keys(graph.outports).length).to.equal 1
+      chai.expect(graph.outports[outport.public]).to.exist()
+      chai.expect(graph.outports[event.payload.to]).not.to.exist()
+
+      eventSocket.send event
+
+      chai.expect(_.keys(graph.outports).length).to.equal 1
+      chai.expect(graph.outports[outport.public]).not.to.exist()
+      chai.expect(graph.outports[event.payload.to]).to.exist()
+
+    it 'should receive addgroup events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      event =
+        protocol: 'graph'
+        command: 'addgroup'
+        payload:
+          graph: 'graph1'
+          name: 'group1'
+          nodes: [node1.id, node2.id]
+          metadata: label: 'hello'
+
+      graph.addNode node1.id, node1.component
+      graph.addNode node2.id, node2.component
+
+      chai.expect(graph.groups.length).to.equal 0
+
+      eventSocket.send event
+      chai.expect(graph.groups.length).to.equal 1
+
+    it 'should receive removegroup events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      group =
+        name: 'group1'
+        nodes: [node1.id, node2.id]
+
+      event =
+        protocol: 'graph'
+        command: 'removegroup'
+        payload:
+          graph: 'graph1'
+          name: 'group1'
+
+      graph.addNode node1.id, node1.component
+      graph.addNode node2.id, node2.component
+      graph.addGroup group.name, group.nodes
+
+      chai.expect(graph.groups.length).to.equal 1
+
+      eventSocket.send event
+      chai.expect(graph.groups.length).to.equal 0
+
+    it 'should receive renamegroup events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      group =
+        name: 'group1'
+        nodes: [node1.id, node2.id]
+
+      event =
+        protocol: 'graph'
+        command: 'renamegroup'
+        payload:
+          graph: 'graph1'
+          from: 'group1'
+          to: 'group2'
+
+      graph.addNode node1.id, node1.component
+      graph.addNode node2.id, node2.component
+      graph.addGroup group.name, group.nodes
+
+      chai.expect(graph.groups.length).to.equal 1
+      chai.expect(graph.groups[0].name).to.equal group.name
+
+      eventSocket.send event
+      chai.expect(graph.groups.length).to.equal 1
+      chai.expect(graph.groups[0].name).to.equal event.payload.to
+
+    it 'should receive changegroup events', ->
+      node1 =
+        id: 'abcd'
+        component: 'core/Kick'
+        metadata: {}
+
+      node2 =
+        id: 'efgh'
+        component: 'core/Drop'
+        metadata: {}
+
+      group =
+        name: 'group1'
+        nodes: [node1.id, node2.id]
+        metadata: label: 'hello'
+
+      event =
+        protocol: 'graph'
+        command: 'changegroup'
+        payload:
+          graph: 'graph1'
+          name: 'group1'
+          metadata: label: 'goodbye'
+
+      graph.addNode node1.id, node1.component
+      graph.addNode node2.id, node2.component
+      graph.addGroup group.name, group.nodes, group.metadata
+
+      chai.expect(graph.groups.length).to.equal 1
+      chai.expect(graph.groups[0].metadata.label).to.equal group.metadata.label
+
+      eventSocket.send event
+      chai.expect(graph.groups.length).to.equal 1
+      chai.expect(graph.groups[0].metadata.label).to.equal event.payload.metadata.label


### PR DESCRIPTION
This pull request allows noflo-ui to respond to commands from the runtime such as addnode, addedge, etc., and update the graph exposed by the graph editor accordingly. It depends on this pull request to noflo-runtime: https://github.com/noflo/noflo-runtime/pull/66

The two pull requests are together intended to address this issue: https://github.com/noflo/noflo-ui/issues/390. 