### PR TITLE
Bugfix: Prevent library search results from firing new library searches

### DIFF
--- a/elements/noflo-library.html
+++ b/elements/noflo-library.html
@@ -81,14 +81,18 @@
               }
             }
           }
-          this.fire('result', {
-            label: component.name,
-            icon: component.icon || 'cog',
-            description: component.description,
-            action: function () {
-              this.addNode(component);
-            }.bind(this)
-          });
+          // timeout required because events fired by polymer that are received
+          // by graph router need to clean up before the graph receives another event
+          window.setTimeout(function () {
+            this.fire('result', {
+              label: component.name,
+              icon: component.icon || 'cog',
+              description: component.description,
+              action: function () {
+                this.addNode(component);
+              }.bind(this)
+            });
+          }.bind(this), 0);
         }.bind(this));
       }
     });


### PR DESCRIPTION
Search events in progress set off search result events, but graph router expects events to finish or the router will keep matching every event that is in progress. This causes each search result to spawn a brand new search. Solved by firing search results asynchronously.

Relevant code:
https://github.com/noflo/noflo-ui/blob/master/graphs/ContextStorage.fbp#L20 this is where both search and search results get forwarded immediately back to the polymer app

https://github.com/noflo/noflo-routers/blob/master/components/GroupRouter.coffee#L63 each event registers how it should match routes here. Because search_library is still in progress when search_library_result gets to this part of the code, search_library will keep matching as each library result passes through.
