### PR TITLE
Load examples for available runtimes from runtime info files

### DIFF
--- a/elements/noflo-main.html
+++ b/elements/noflo-main.html
@@ -448,7 +448,32 @@
         if (event) {
           event.preventDefault();
         }
+
+        function addExamplesForRuntimes() {
+          // Add examples for all current runtimes
+          var runtimeInfo = require('noflo-ui/runtimeinfo');
+          var runtimeTypesFound = {};
+          var examplesFound = {};
+          this.examples = [];
+
+          this.runtimes.forEach(function (runtime) {
+
+            // If this is the first registry of its type, add examples for it
+            if (!runtimeTypesFound[runtime.type] && runtimeInfo[runtime.type]) {
+              var examples = runtimeInfo[runtime.type].examples;
+
+              Object.keys(examples).forEach(function (key) {
+                if (!examplesFound[key]) {
+                  this.examples.push(examples[key]);
+                  examplesFound[key] = true;
+                }
+              }.bind(this));
+            }
+          }.bind(this));
+        }
+
         if (!this.gridToken) {
+          addExamplesForRuntimes.bind(this)();
           return;
         }
         var button = this.$.fetchruntimes;
@@ -507,26 +532,8 @@
             this.userRuntimes.splice(index, 1);
           }.bind(this));
 
-          // Add examples for all current runtimes
-          var runtimeInfo = require('noflo-ui/runtimeinfo');
-          var runtimeTypesFound = {};
-          var examplesFound = {};
-          this.examples = [];
+          addExamplesForRuntimes.bind(this)();
 
-          this.runtimes.forEach(function (runtime) {
-
-            // If this is the first registry of its type, add examples for it
-            if (!runtimeTypesFound[runtime.type] && runtimeInfo[runtime.type]) {
-              var examples = runtimeInfo[runtime.type].examples;
-
-              Object.keys(examples).forEach(function (key) {
-                if (!examplesFound[key]) {
-                  this.examples.push(examples[key]);
-                  examplesFound[key] = true;
-                }
-              }.bind(this));
-            }
-          }.bind(this));
         }.bind(this));
       },
       gridTokenChanged: function () {

--- a/elements/noflo-main.html
+++ b/elements/noflo-main.html
@@ -272,40 +272,7 @@
       remoteProjects: [],
       runtimes: [],
       userRuntimes: [],
-      examples: [
-        {
-          label: 'Photo booth',
-          id: '7804187'
-        },
-        {
-          label: 'Animated clock',
-          id: '7135158'
-        },
-        {
-          label: 'Cam to palette',
-          id: '3c0ffdf17195649a2d57'
-        },
-        {
-          label: 'Canvas pattern',
-          id: '1319c76fe006fb34c9c9'
-        },
-        {
-          label: 'Yin-yang',
-          id: 'a1096a406131e109f836'
-        },
-        {
-          label: 'Delaunay masks',
-          id: 'f6d1141de2833e45fb3c'
-        },
-        {
-          label: 'React TODO list',
-          id: '1d42f66f5cc4614df935'
-        },
-        {
-          label: 'Web Audio',
-          id: '04847249319d2326fa92'
-        }
-      ],
+      examples: [],
       githubToken: '',
       gridToken: '',
       user: null,
@@ -538,6 +505,27 @@
             }
             this.fire('removedruntime', runtime);
             this.userRuntimes.splice(index, 1);
+          }.bind(this));
+
+          // Add examples for all current runtimes
+          var runtimeInfo = require('noflo-ui/runtimeinfo');
+          var runtimeTypesFound = {};
+          var examplesFound = {};
+          this.examples = [];
+
+          this.runtimes.forEach(function (runtime) {
+
+            // If this is the first registry of its type, add examples for it
+            if (!runtimeTypesFound[runtime.type] && runtimeInfo[runtime.type]) {
+              var examples = runtimeInfo[runtime.type].examples;
+
+              Object.keys(examples).forEach(function (key) {
+                if (!examplesFound[key]) {
+                  this.examples.push(examples[key]);
+                  examplesFound[key] = true;
+                }
+              }.bind(this));
+            }
           }.bind(this));
         }.bind(this));
       },

--- a/runtimeinfo/imgflo.yaml
+++ b/runtimeinfo/imgflo.yaml
@@ -59,3 +59,5 @@ componenttemplates:
     }
 
     #endif
+
+examples: {}

--- a/runtimeinfo/javafbp.yaml
+++ b/runtimeinfo/javafbp.yaml
@@ -8,3 +8,5 @@ runtimetypes:
 componenttemplates:
   'java': |
     // TODO
+
+examples: {}

--- a/runtimeinfo/microflo.yaml
+++ b/runtimeinfo/microflo.yaml
@@ -8,3 +8,5 @@ runtimetypes:
 componenttemplates:
   'c++': |
     // TODO
+
+examples: {}

--- a/runtimeinfo/msgflo.yaml
+++ b/runtimeinfo/msgflo.yaml
@@ -110,3 +110,5 @@ componenttemplates:
         queue: /bitraf/door/#ROLE/open
         type: object
     outports: {}
+
+examples: {}

--- a/runtimeinfo/noflo.yaml
+++ b/runtimeinfo/noflo.yaml
@@ -99,3 +99,29 @@ componenttemplates:
       });
       return c;
     };
+
+examples:
+  photobooth:
+    label: 'Photo booth'
+    id: '7804187'
+  clock:
+    label: 'Animated clock'
+    id: '7135158'
+  camtopalette:
+    label: 'Cam to palette'
+    id: '3c0ffdf17195649a2d57'
+  canvas:
+    label: 'Canvas pattern'
+    id: '1319c76fe006fb34c9c9'
+  yinyang:
+    label: 'Yin-yang'
+    id: 'a1096a406131e109f836'
+  delaunaymasks:
+    label: 'Delaunay masks'
+    id: 'f6d1141de2833e45fb3c'
+  reacttodo:
+    label: 'React TODO list'
+    id: '1d42f66f5cc4614df935'
+  webaudio:
+    label: 'Web Audio'
+    id: '04847249319d2326fa92'

--- a/runtimeinfo/sndflo.yaml
+++ b/runtimeinfo/sndflo.yaml
@@ -18,3 +18,5 @@ componenttemplates:
             )
         )
     )
+
+examples: {}


### PR DESCRIPTION
Fixes #617 by adding information about the examples for each runtime type in the runtime info YAML files. As runtimes are updated in the UI, so are the examples.
