### PR TITLE
Safari 10 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 NoFlo UI ChangeLog
 ==================
 
+# 0.14.1 (git master)
+
+Bugfixes
+
+* Safari 10 compatibility
+
 # 0.14.0 (2016 December 14)
 
 Breaking changes

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -332,7 +332,7 @@ module.exports = ->
             version: '39'
           ,
             browserName: 'safari'
-            version: '9'
+            version: '10'
           ,
             browserName: 'internet explorer'
             version: '11'

--- a/index.dist.html
+++ b/index.dist.html
@@ -30,12 +30,6 @@
     <script src="node_modules/react/dist/react-with-addons.js"></script>
     <script src="node_modules/react-dom/dist/react-dom.js"></script>
     <script src="node_modules/indexeddbshim/dist/indexeddbshim.min.js"></script>
-    <script>
-      if (navigator.vendor && navigator.vendor.indexOf('Apple') !== -1) {
-        console.log('Safari detected, replacing broken IndexedDB with shim');
-        window.shimIndexedDB.__useShim();
-      }
-    </script>
     <script src="node_modules/rtc/dist/rtc.js"></script>
 
     <script src="../node_modules/codemirror/lib/codemirror.js"></script>


### PR DESCRIPTION
Fixes Safari 10 support by removing the forced IndexedDB shim introduced in #522 

Currently CI seems to have trouble, but tested manually at SauceLabs:

![screenshot 2017-01-12 at 19 45 08](https://cloud.githubusercontent.com/assets/3346/21903740/5af0e6a6-d901-11e6-89d8-21f1eb7d12a2.png)
