### PR TITLE
Build only graph deps

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -13,6 +13,7 @@ module.exports = ->
     # Browser build of NoFlo
     noflo_browser:
       options:
+        graph: 'ui/main'
         manifest:
           runtimes: [
             'noflo'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "grunt-gh-pages": "^2.0.0",
     "grunt-lint-inline": "^1.0.0",
     "grunt-mocha-phantomjs": "^4.0.0",
-    "grunt-noflo-browser": "^1.1.1",
+    "grunt-noflo-browser": "^1.1.5",
     "grunt-saucelabs": "^9.0.0",
     "grunt-string-replace": "^1.3.1",
     "grunt-vulcanize": "^0.4.2",


### PR DESCRIPTION
This drops NoFlo components that are not used in the app out of the bundle. About 11% size reduction, with more to come with other dependency harmonization