### PR TITLE
Runtime middleware

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -371,11 +371,15 @@ module.exports = ->
           'spec/tests.html': ['spec/*.js']
     # BDD tests on browser
     mocha_phantomjs:
-      all:
+      unit:
         options:
           reporter: 'spec'
           urls: ['http://localhost:9999/spec/tests.html']
           failWithOutput: true
+      browser:
+        options:
+          reporter: 'spec'
+          urls: ['http://localhost:9999/spec/browser/tests.html']
 
     # BDD tests on browser
     'saucelabs-mocha':
@@ -413,7 +417,6 @@ module.exports = ->
   @loadNpmTasks 'grunt-gh-pages'
 
   # Grunt plugins used for testing
-  #@loadNpmTasks 'grunt-mocha-phantomjs'
   @loadNpmTasks 'grunt-contrib-watch'
   @loadNpmTasks 'grunt-contrib-coffee'
   @loadNpmTasks 'grunt-mocha-phantomjs'

--- a/app/main.js
+++ b/app/main.js
@@ -5,6 +5,7 @@ var exported = {
   'child_process': null,
   'uuid': require('uuid'),
   'flowhub-registry': require('flowhub-registry'),
+  'fbp-protocol-client': require('fbp-protocol-client'),
   'noflo-ui/src/JournalStore': require('../src/JournalStore'),
   'noflo-ui/runtimeinfo': require('../runtimeinfo/index.coffee')
 };

--- a/components/CheckTokenGrant.coffee
+++ b/components/CheckTokenGrant.coffee
@@ -19,9 +19,9 @@ exports.getComponent = ->
     async: true
   , (data, groups, out, callback) ->
     # Check the URL for a OAuth grant code
-    unless typeof data is 'string'
+    unless typeof data.payload is 'string'
       return callback new Error 'URL must be a string'
-    [url, query] = data.split '?'
+    [url, query] = data.payload.split '?'
     unless query
       # No query params, pass out as-is
       out.pass.send data

--- a/components/CleanAction.coffee
+++ b/components/CleanAction.coffee
@@ -2,17 +2,14 @@ noflo = require 'noflo'
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.description = 'Strips state from action payloads for backwards compat'
   c.inPorts.add 'in',
-    datatype: 'string'
+    datatype: 'object'
   c.outPorts.add 'out',
-    datatype: 'bang'
-
+    datatype: 'object'
   noflo.helpers.WirePattern c,
     async: true
-    forwardGroups: false
+    forwardGroups: true
   , (data, groups, out, callback) ->
-    # This will in effect cause a NoFlo network stop as the app
-    # redirects to new URL
-    window.location.href = data.payload
-    out.send true
+    out.send data.payload or data
     do callback

--- a/components/GetActionValues.coffee
+++ b/components/GetActionValues.coffee
@@ -1,0 +1,42 @@
+noflo = require 'noflo'
+
+getValues = (keys, state) ->
+  values = keys.map (key) ->
+    return state[key] if key.indexOf('[') is -1
+    matched = key.match /(.*)\[([0-9]+|last)\]/
+    return null unless matched
+    arr = state[matched[1]]
+    if matched[2] is 'last'
+      return arr[arr.length - 1]
+    arr[matched[2]]
+  return values
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.description = 'Reads requested keys from action and sends them out alongside the action payload'
+  c.inPorts.add 'in',
+    datatype: 'object'
+  c.inPorts.add 'keys',
+    datatype: 'string'
+  c.outPorts.add 'values',
+    datatype: 'all'
+    addressable: yes
+  c.outPorts.add 'out',
+    datatype: 'object'
+  noflo.helpers.WirePattern c,
+    in: 'in'
+    params: 'keys'
+    out: 'out'
+    async: true
+    forwardGroups: true
+  , (data, groups, out, callback) ->
+    if not c.params.keys or not data.state or not data.payload
+      out.send data.payload or data
+      do callback
+      return
+    keys = c.params.keys.split ','
+    values = getValues keys, data.state
+    for value, idx in values
+      c.outPorts.values.send value, idx
+    out.send data.payload
+    do callback

--- a/components/LoggingMiddleware.coffee
+++ b/components/LoggingMiddleware.coffee
@@ -17,6 +17,6 @@ exports.getComponent = ->
   , (data, groups, out, callback) ->
     action = groups.join ':'
     debugAction action
-    debugActionFull action, data
+    debugActionFull action, data.payload
     out.send data
     do callback

--- a/components/LoginOAuth.coffee
+++ b/components/LoginOAuth.coffee
@@ -40,14 +40,14 @@ exports.getComponent = ->
         interactive: true
         url: getUrl
           url: chrome.identity.getRedirectURL()
-          scopes: data.scopes
+          scopes: data.payload.scopes
       , (responseUrl) ->
         out.codeurl.send responseUrl
         do callback
       return
 
-    unless isRedirectValid data.url
+    unless isRedirectValid data.payload.url
       return callback new Error "App URL must match GitHub app configuration $NOFLO_OAUTH_CLIENT_REDIRECT"
 
-    out.redirect.send getUrl data
+    out.redirect.send getUrl data.payload
     do callback

--- a/components/Router.coffee
+++ b/components/Router.coffee
@@ -68,12 +68,14 @@ exports.getComponent = ->
   , (url, groups, out, callback) ->
     ctx = buildContext url
     unless ctx
-      out.missed.send ctx
+      out.missed.send
+        payload: ctx
       return callback()
 
     out.route.beginGroup ctx.route
     out.route.beginGroup 'open'
-    out.route.send ctx
+    out.route.send
+      payload: ctx
     out.route.endGroup()
     out.route.endGroup()
     callback()

--- a/components/SetAction.coffee
+++ b/components/SetAction.coffee
@@ -19,7 +19,8 @@ exports.getComponent = ->
     actionParts = c.params.action.split ':'
     setTimeout ->
       out.beginGroup part for part in actionParts
-      out.send data
+      out.send
+        payload: data
       out.endGroup() for part in actionParts
       callback()
     , 1

--- a/components/StateMiddleware.coffee
+++ b/components/StateMiddleware.coffee
@@ -1,0 +1,31 @@
+noflo = require 'noflo'
+debug = require('debug') 'noflo-ui:state'
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.inPorts.add 'in',
+    datatype: 'all'
+  c.outPorts.add 'pass',
+    datatype: 'object'
+
+  c.state = {}
+  c.shutdown = ->
+    c.state = {}
+  noflo.helpers.WirePattern c,
+    in: 'in'
+    out: 'pass'
+    forwardGroups: true
+    async: true
+  , (data, groups, out, callback) ->
+    if data?.state
+      # Keep track of last state
+      c.state = data.state
+    else
+      # Warn of actions that don't contain state
+      debug "#{groups.join(':')} was sent without state, using previous state"
+    state = data?.state or c.state
+    payload = data?.payload or data
+    out.send
+      state: state
+      payload: payload
+    do callback

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -124,7 +124,10 @@
           this.fire('project:save:runtime', event.detail);
         }.bind(this));
         this.$.grapheditor.addEventListener('edges', function (event) {
-          this.fire('context:edges', event.detail);
+          this.fire('context:edges', {
+            graph: this.$.grapheditor.graph.name || this.$.grapheditor.graph.properties.id,
+            edges: event.detail
+          });
         }.bind(this));
         this.$.grapheditor.addEventListener('nodes', function (event) {
           this.fire('context:nodes', event.detail);
@@ -306,7 +309,7 @@
           this.$.search.graphResults(this.ctx.searchGraphResult);
         }
         if (this.ctx.edges !== undefined) {
-          this.$.packets.edges = this.ctx.edges;
+          this.$.packets.edges = this.ctx.edges.edges;
         }
         if (this.ctx.error) {
           this.$.packets.processError(this.ctx.error);

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -60,12 +60,18 @@
       height: window.innerHeight,
       ctx: {},
       dontAutoHideAlert: false,
+      emitEvent: function (event, payload) {
+        this.fire(event, {
+          state: this.ctx,
+          payload: payload
+        });
+      },
       ready: function () {
         this.$.main.addEventListener('logout', function (event) {
-          this.fire('user:logout', true);
+          this.emitEvent('user:logout', true);
         }.bind(this));
         this.$.main.addEventListener('login', function (event) {
-          this.fire('user:login', {
+          this.emitEvent('user:login', {
             url: window.location.href,
             scopes: []
           });
@@ -75,18 +81,18 @@
           if (event.detail !== 'free') {
             scopes = ['repo'];
           }
-          this.fire('user:login', {
+          this.emitEvent('user:login', {
             url: window.location.href,
             scopes: []
           });
         }.bind(this));
         this.$.main.addEventListener('fetchRemote', function (event) {
-          this.fire('github:fetch', event.detail);
+          this.emitEvent('github:fetch', event.detail);
         }.bind(this));
         this.$.main.addEventListener('downloadProject', function (event) {
-          this.fire('project:save:project', event.detail.project);
+          this.emitEvent('project:save:project', event.detail.project);
           setTimeout(function () {
-            this.fire('github:sync:pull', {
+            this.emitEvent('github:sync:pull', {
               repo: event.detail.project.repo,
               project: event.detail.project
             });
@@ -96,21 +102,21 @@
           }.bind(this), 2);
         }.bind(this));
         this.$.main.addEventListener('newgraph', function (event) {
-          this.fire('project:save:graph', event.detail);
+          this.emitEvent('project:save:graph', event.detail);
         }.bind(this));
         this.$.main.addEventListener('runtime', function (event) {
-          this.fire('project:save:runtime', event.detail);
+          this.emitEvent('project:save:runtime', event.detail);
         }.bind(this));
         this.$.main.addEventListener('newproject', function (event) {
-          this.fire('project:save:project', event.detail);
+          this.emitEvent('project:save:project', event.detail);
           this.ctx.projects.push(event.detail);
           setTimeout(function () {
             window.location.hash = '#project/' + encodeURIComponent(event.detail.id) + '/' + encodeURIComponent(event.detail.main);
           }, 2);
         }.bind(this));
         this.$.context.addEventListener('newgraph', function (event) {
-          this.fire('project:save:graph', event.detail);
-          this.fire('runtime:sendGraph', event.detail);
+          this.emitEvent('project:save:graph', event.detail);
+          this.emitEvent('runtime:sendGraph', event.detail);
         }.bind(this));
         this.$.runtime.addEventListener('runtime', function (event) {
           var newCtx = {};
@@ -118,85 +124,82 @@
             newCtx[key] = this.ctx[key];
           }
           newCtx.runtime = event.detail;
-          this.fire('runtime:connect', newCtx);
+          this.emitEvent('runtime:connect', newCtx);
         }.bind(this));
         this.$.runtime.addEventListener('changed', function (event) {
-          this.fire('project:save:runtime', event.detail);
+          this.emitEvent('project:save:runtime', event.detail);
         }.bind(this));
         this.$.grapheditor.addEventListener('edges', function (event) {
-          this.fire('context:edges', {
-            graph: this.$.grapheditor.graph.name || this.$.grapheditor.graph.properties.id,
-            edges: event.detail
-          });
+          this.emitEvent('context:edges', event.detail);
         }.bind(this));
         this.$.grapheditor.addEventListener('nodes', function (event) {
-          this.fire('context:nodes', event.detail);
+          this.emitEvent('context:nodes', event.detail);
         }.bind(this));
         this.$.project.addEventListener('changed', function (event) {
-          this.fire('project:save:project', event.detail);
+          this.emitEvent('project:save:project', event.detail);
         }.bind(this));
         this.$.project.addEventListener('newgraph', function (event) {
-          this.fire('project:save:graph', event.detail);
-          this.fire('runtime:sendGraph', event.detail);
+          this.emitEvent('project:save:graph', event.detail);
+          this.emitEvent('runtime:sendGraph', event.detail);
           this.triggerTests();
         }.bind(this));
         this.$.project.addEventListener('newcomponent', function (event) {
-          this.fire('project:save:component', event.detail);
-          this.fire('runtime:sendComponent', event.detail);
+          this.emitEvent('project:save:component', event.detail);
+          this.emitEvent('runtime:sendComponent', event.detail);
         }.bind(this));
         this.$.project.addEventListener('sync', function (event) {
-          this.fire('github:sync:prepare', event.detail);
+          this.emitEvent('github:sync:prepare', event.detail);
         }.bind(this));
         this.$.project.addEventListener('syncDecision', function (event) {
-          this.fire('github:sync:synchronize', event.detail);
+          this.emitEvent('github:sync:synchronize', event.detail);
         }.bind(this));
         this.$.project.addEventListener('deleteProject', function (event) {
           window.location.hash = '#';
           event.detail.graphs.forEach(function (graph) {
-            this.fire('project:delete:graph', graph);
+            this.emitEvent('project:delete:graph', graph);
           }.bind(this));
           event.detail.components.forEach(function (component) {
-            this.fire('project:delete:component', component);
+            this.emitEvent('project:delete:component', component);
           }.bind(this));
           event.detail.specs.forEach(function (spec) {
-            this.fire('project:delete:spec', spec);
+            this.emitEvent('project:delete:spec', spec);
           }.bind(this));
-          this.fire('project:delete:project', event.detail);
+          this.emitEvent('project:delete:project', event.detail);
           this.$.main.projects.splice(this.$.main.projects.indexOf(event.detail), 1);
           this.$.main.localProjects.splice(this.$.main.localProjects.indexOf(event.detail), 1);
         }.bind(this));
         this.$.main.addEventListener('deleteProject', function (event) {
           window.location.hash = '#';
           event.detail.graphs.forEach(function (graph) {
-            this.fire('project:delete:graph', graph);
+            this.emitEvent('project:delete:graph', graph);
           }.bind(this));
           event.detail.components.forEach(function (component) {
-            this.fire('project:delete:component', component);
+            this.emitEvent('project:delete:component', component);
           }.bind(this));
           event.detail.specs.forEach(function (spec) {
-            this.fire('project:delete:spec', spec);
+            this.emitEvent('project:delete:spec', spec);
           }.bind(this));
-          this.fire('project:delete:project', event.detail);
+          this.emitEvent('project:delete:project', event.detail);
           this.$.main.projects.splice(this.$.main.projects.indexOf(event.detail), 1);
           this.$.main.localProjects.splice(this.$.main.localProjects.indexOf(event.detail), 1);
         }.bind(this));
         this.$.componenteditor.addEventListener('changed', function (event) {
-          this.fire('project:save:component', event.detail);
-          this.fire('runtime:sendComponent', event.detail);
+          this.emitEvent('project:save:component', event.detail);
+          this.emitEvent('runtime:sendComponent', event.detail);
           this.triggerTests();
         }.bind(this));
         this.$.componenteditor.addEventListener('specschanged', function (event) {
-          this.fire('project:save:spec', event.detail);
+          this.emitEvent('project:save:spec', event.detail);
           this.triggerTests();
         }.bind(this));
         this.$.search.addEventListener('search:library', function (event) {
-          this.fire('context:search_library', event.detail);
+          this.emitEvent('context:search_library', event.detail);
         }.bind(this));
         this.$.search.addEventListener('search:graph', function (event) {
-          this.fire('context:search_graph', event.detail);
+          this.emitEvent('context:search_graph', event.detail);
         }.bind(this));
         this.$.library.addEventListener('result', function (event) {
-          this.fire('context:search_library_result', {
+          this.emitEvent('context:search_library_result', {
             searchLibraryResult: event.detail
           });
         }.bind(this));
@@ -205,10 +208,10 @@
           if (project && project.graphs.indexOf(event.detail) !== -1) {
             project.graphs.splice(project.graphs.indexOf(event.detail), 1);
           }
-          this.fire('project:delete:graph', event.detail);
+          this.emitEvent('project:delete:graph', event.detail);
           if (!project.graphs.length && !project.components.length) {
             // Empty project, remove
-            this.fire('project:delete:project', project);
+            this.emitEvent('project:delete:project', project);
             this.$.main.projects.splice(this.$.main.projects.indexOf(project), 1);
             this.$.main.localProjects.splice(this.$.main.localProjects.indexOf(project), 1);
             // Go home
@@ -231,10 +234,10 @@
           if (index !== -1) {
             project.components.splice(index, 1);
           }
-          this.fire('project:delete:component', component);
+          this.emitEvent('project:delete:component', component);
           if (!project.graphs.length && !project.components.length) {
             // Empty project, remove
-            this.fire('project:delete:project', project);
+            this.emitEvent('project:delete:project', project);
             this.$.main.projects.splice(this.$.main.projects.indexOf(project), 1);
             this.$.main.localProjects.splice(this.$.main.localProjects.indexOf(project), 1);
             // Go home
@@ -248,7 +251,7 @@
           }
         }.bind(this));
         this.$.search.addEventListener('specschanged', function (event) {
-          this.fire('project:save:spec', event.detail);
+          this.emitEvent('project:save:spec', event.detail);
           this.triggerTests();
         }.bind(this));
         this.$.library.editor = this.$.grapheditor;
@@ -309,7 +312,7 @@
           this.$.search.graphResults(this.ctx.searchGraphResult);
         }
         if (this.ctx.edges !== undefined) {
-          this.$.packets.edges = this.ctx.edges.edges;
+          this.$.packets.edges = this.ctx.edges;
         }
         if (this.ctx.error) {
           this.$.packets.processError(this.ctx.error);
@@ -373,7 +376,7 @@
           this.$.runtime.graph = this.ctx.graphs[0];
           if (oldGraph !== this.$.grapheditor.graph) {
             setTimeout(function () {
-              this.fire('context:graph', {
+              this.emitEvent('context:graph', {
                 graph: this.$.grapheditor.graph
               });
             }.bind(this), 1);
@@ -428,7 +431,7 @@
         }
       },
       triggerTests: function () {
-        this.fire('runtime:runTests', this.ctx.project || this.$.project.project);
+        this.emitEvent('runtime:runTests', this.ctx.project || this.$.project.project);
       },
       hideAlert: function () {
         this.$.alert.classList.remove('show');

--- a/graphs/ContextStorage.fbp
+++ b/graphs/ContextStorage.fbp
@@ -9,7 +9,6 @@ Dispatch OUT[0] -> IN SplitEdges(core/Split) OUT -> START CreateEdgeCtx(objects/
 CreateEdgeCtx OUT -> CONTEXT SetEdges(ui/SetToContext)
 'edges' -> KEY SetEdges
 SplitEdges OUT -> VALUE SetEdges CONTEXT -> IN MergeContext(core/Merge)
-# TODO: Send to runtime
 
 # Selected nodes
 Dispatch OUT[1] -> IN SplitNodes(core/Split) OUT -> START CreateNodeCtx(objects/CreateObject)

--- a/graphs/RuntimeMiddleware.fbp
+++ b/graphs/RuntimeMiddleware.fbp
@@ -1,0 +1,16 @@
+INPORT=Dispatch.IN:IN
+OUTPORT=Passed.OUT:PASS
+OUTPORT=NewActions.OUT:NEW
+
+'runtime:connected,context:edges' -> ROUTES Dispatch(ui/DispatchAction)
+
+# Pass connected runtime to all handlers and also outside
+Dispatch HANDLE[0] -> IN Runtimes(core/Merge)
+Runtimes OUT -> IN Passed(core/Merge)
+Dispatch PASS -> IN Passed
+
+# Send selected edges to runtime
+Dispatch HANDLE[1] -> EDGES SendEdges(runtime/SendEdges)
+Runtimes OUT -> RUNTIME SendEdges OUT -> IN Passed
+
+NewActions(core/Merge)

--- a/graphs/RuntimeMiddleware.fbp
+++ b/graphs/RuntimeMiddleware.fbp
@@ -2,15 +2,16 @@ INPORT=Dispatch.IN:IN
 OUTPORT=Passed.OUT:PASS
 OUTPORT=NewActions.OUT:NEW
 
-'runtime:connected,context:edges' -> ROUTES Dispatch(ui/DispatchAction)
-
-# Pass connected runtime to all handlers and also outside
-Dispatch HANDLE[0] -> IN Runtimes(core/Merge)
-Runtimes OUT -> IN Passed(core/Merge)
-Dispatch PASS -> IN Passed
+'context:edges' -> ROUTES Dispatch(ui/DispatchAction)
 
 # Send selected edges to runtime
-Dispatch HANDLE[1] -> EDGES SendEdges(runtime/SendEdges)
-Runtimes OUT -> RUNTIME SendEdges OUT -> IN Passed
+'runtime,graphs[0]' -> KEYS GetEdgeState(ui/GetActionValues)
+Dispatch HANDLE[0] -> IN GetEdgeState
+GetEdgeState VALUES[0] -> RUNTIME SendEdges(runtime/SendEdges)
+GetEdgeState VALUES[1] -> GRAPH SendEdges
+GetEdgeState OUT -> EDGES SendEdges
+
+SendEdges OUT -> IN Passed(core/Merge)
+Dispatch PASS -> IN Passed
 
 NewActions(core/Merge)

--- a/graphs/RuntimeStorage.fbp
+++ b/graphs/RuntimeStorage.fbp
@@ -2,7 +2,7 @@ INPORT=LoadData.DB:DB
 INPORT=Dispatch.IN:IN
 INPORT=FindRuntimes.CONTEXT:CONTEXT
 OUTPORT=MergeContext.OUT:CONTEXT
-OUTPORT=UpdateLibrary.RUNTIME:OUT
+OUTPORT=NewActions.OUT:NEW
 
 # Route requests
 'open,connect,sendGraph,sendComponent,runTests' -> ROUTES Dispatch(routers/GroupRouter)
@@ -38,6 +38,7 @@ ProjectRuntime RUNTIME -> RUNTIME ListComponents(runtime/ListComponents)
 DirectRuntime RUNTIME -> RUNTIME ListComponents
 ListComponents OUT -> IN UpdateLibrary
 UpdateLibrary OUT -> IN MergeContext
+UpdateRuntime OUT -> IN NewActions(core/Split)
 ListComponents ERROR -> IN ShowErrors
 
 # Graph change subscription

--- a/graphs/RuntimeStorage.fbp
+++ b/graphs/RuntimeStorage.fbp
@@ -41,6 +41,12 @@ UpdateLibrary OUT -> IN MergeContext
 UpdateRuntime OUT -> IN NewActions(core/Split)
 ListComponents ERROR -> IN ShowErrors
 
+# Send runtime information as a new action
+'runtime:connected' -> ACTION RuntimeConnectionAction(ui/SetAction)
+RuntimeConnectionAction OUT -> IN NewActions
+ProjectRuntime CONNECTED -> IN RuntimeConnectionAction
+DirectRuntime RUNTIME -> IN RuntimeConnectionAction
+
 # Graph change subscription
 MergeContextPreSubscribe OUT -> CONTEXT SubscribeGraph(ui/SubscribeGraph)
 SubscribeGraph RUNTIME -> RUNTIME SendGraph(runtime/SendGraphChanges)

--- a/graphs/RuntimeStorage.fbp
+++ b/graphs/RuntimeStorage.fbp
@@ -2,7 +2,7 @@ INPORT=LoadData.DB:DB
 INPORT=Dispatch.IN:IN
 INPORT=FindRuntimes.CONTEXT:CONTEXT
 OUTPORT=MergeContext.OUT:CONTEXT
-OUTPORT=NewActions.OUT:NEW
+OUTPORT=UpdateLibrary.RUNTIME:NEW
 
 # Route requests
 'open,connect,sendGraph,sendComponent,runTests' -> ROUTES Dispatch(routers/GroupRouter)
@@ -38,14 +38,7 @@ ProjectRuntime RUNTIME -> RUNTIME ListComponents(runtime/ListComponents)
 DirectRuntime RUNTIME -> RUNTIME ListComponents
 ListComponents OUT -> IN UpdateLibrary
 UpdateLibrary OUT -> IN MergeContext
-UpdateRuntime OUT -> IN NewActions(core/Split)
 ListComponents ERROR -> IN ShowErrors
-
-# Send runtime information as a new action
-'runtime:connected' -> ACTION RuntimeConnectionAction(ui/SetAction)
-RuntimeConnectionAction OUT -> IN NewActions
-ProjectRuntime CONNECTED -> IN RuntimeConnectionAction
-DirectRuntime RUNTIME -> IN RuntimeConnectionAction
 
 # Graph change subscription
 MergeContextPreSubscribe OUT -> CONTEXT SubscribeGraph(ui/SubscribeGraph)

--- a/graphs/main.fbp
+++ b/graphs/main.fbp
@@ -12,8 +12,10 @@ Logger PASS -> IN UrlMiddleware(ui/UrlMiddleware)
 UrlMiddleware NEW -> IN Actions
 UrlMiddleware PASS -> IN UserMiddleware(ui/UserMiddleware)
 UserMiddleware NEW -> IN Actions
+UserMiddleware PASS -> IN RuntimeMiddleware(ui/RuntimeMiddleware)
+RuntimeMiddleware NEW -> IN Actions
 # Once middlewares have processed event, pass to stores
-UserMiddleware PASS -> IN Dispatch(routers/GroupRouter)
+RuntimeMiddleware PASS -> IN Dispatch(routers/GroupRouter)
 'user,main,project,github,runtime,context' -> ROUTES Dispatch
 Dispatch OUT[0] -> IN UserReducer(ui/UserReducer)
 Dispatch OUT[1] -> START MainContext(ui/CreateContext)

--- a/graphs/main.fbp
+++ b/graphs/main.fbp
@@ -7,7 +7,8 @@ PrepareStorage DB -> DB RuntimeStorage(ui/RuntimeStorage)
 AppView(polymer/noflo-ui) EVENT -> IN Actions(core/Repeat)
 # First we send the events to middlewares, and allow them
 # to either pass along or generate new events
-Actions OUT -> IN Logger(ui/LoggingMiddleware)
+Actions OUT -> IN HandleState(ui/StateMiddleware)
+HandleState PASS -> IN Logger(ui/LoggingMiddleware)
 Logger PASS -> IN UrlMiddleware(ui/UrlMiddleware)
 UrlMiddleware NEW -> IN Actions
 UrlMiddleware PASS -> IN UserMiddleware(ui/UserMiddleware)
@@ -15,7 +16,7 @@ UserMiddleware NEW -> IN Actions
 UserMiddleware PASS -> IN RuntimeMiddleware(ui/RuntimeMiddleware)
 RuntimeMiddleware NEW -> IN Actions
 # Once middlewares have processed event, pass to stores
-RuntimeMiddleware PASS -> IN Dispatch(routers/GroupRouter)
+RuntimeMiddleware PASS -> IN Clean(ui/CleanAction) OUT -> IN Dispatch(routers/GroupRouter)
 'user,main,project,github,runtime,context' -> ROUTES Dispatch
 Dispatch OUT[0] -> IN UserReducer(ui/UserReducer)
 Dispatch OUT[1] -> START MainContext(ui/CreateContext)

--- a/graphs/main.fbp
+++ b/graphs/main.fbp
@@ -35,7 +35,7 @@ GithubStorage OUT -> IN ProjectStorage
 # Pass ready contexts to the UI
 MainContext OUT -> CONTEXT AppView
 RuntimeStorage CONTEXT -> CONTEXT AppView
-RuntimeStorage OUT -> IN Actions
+RuntimeStorage NEW -> IN Actions
 ContextStorage CONTEXT -> CONTEXT AppView
 
 # Start the app

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "noflo-objects": "~0.2.0",
     "noflo-polymer": "~0.2.0",
     "noflo-routers": "~0.2.2",
-    "noflo-runtime": "~0.3.8",
+    "noflo-runtime": "~0.3.9",
     "noflo-runtime-base": "^0.7.3",
     "noflo-runtime-webrtc": "~0.7.3",
     "noflo-strings": "~0.2.0",

--- a/spec/RuntimeMiddleware.coffee
+++ b/spec/RuntimeMiddleware.coffee
@@ -115,7 +115,7 @@ describe 'Runtime Middleware', ->
       send actionIn, action, payload
   describe 'receiving a context:edges action', ->
     it 'should send selected edges to the runtime', (done) ->
-      expectedEdges = [
+      sentEdges = [
         from:
           node: 'Foo'
           port: 'out'
@@ -123,7 +123,15 @@ describe 'Runtime Middleware', ->
           node: 'Bar'
           port: 'in'
       ]
-      send actionIn, 'context:edges', expectedEdges,
+      expectedEdges = [
+        src:
+          node: 'Foo'
+          port: 'out'
+        tgt:
+          node: 'Bar'
+          port: 'in'
+      ]
+      send actionIn, 'context:edges', sentEdges,
         graphs: [
           name: 'foo'
         ]

--- a/spec/RuntimeMiddleware.coffee
+++ b/spec/RuntimeMiddleware.coffee
@@ -8,18 +8,89 @@ else
   baseDir = 'noflo-ui'
 
 describe 'Runtime Middleware', ->
+  c = null
+  actionIn = null
+  passAction = null
+  newAction = null
   runtime = null
   before (done) ->
+    @timeout 4000
     fixtures = document.getElementById 'fixtures'
     transport = require('fbp-protocol-client').getTransport 'iframe'
     runtime = new transport
       address: 'mockruntime.html'
     runtime.setParentElement fixtures
     window.runtime = runtime
-    done()
 
+    loader = new noflo.ComponentLoader baseDir
+    loader.load 'ui/RuntimeMiddleware', (err, instance) ->
+      return done err if err
+      c = instance
+      actionIn = noflo.internalSocket.createSocket()
+      c.inPorts.in.attach actionIn
+      actionIn.port = 'in'
+      ###
+      c.network.on 'begingroup', (data) ->
+        console.log "   < #{data.id}"
+      c.network.on 'data', (data) ->
+        console.log "DATA #{data.id}"
+      c.network.on 'endgroup', (data) ->
+        console.log "   > #{data.id}"
+      ###
+      c.start()
+      c.network.once 'start', ->
+        done()
+  beforeEach ->
+    passAction = noflo.internalSocket.createSocket()
+    c.outPorts.pass.attach passAction
+    passAction.port = 'pass'
+    newAction = noflo.internalSocket.createSocket()
+    c.outPorts.new.attach newAction
+    newAction.port = 'new'
   afterEach ->
+    c.outPorts.pass.detach passAction
+    c.outPorts.new.detach newAction
     runtime.iframe.contentWindow.clearMessages()
+
+  send = (socket, action, payload) ->
+    actionParts = action.split ':'
+    socket.beginGroup part for part in actionParts
+    socket.send payload
+    socket.endGroup part for part in actionParts
+
+  receive = (socket, expected, check, done) ->
+    received = []
+    onBeginGroup = (group) ->
+      received.push "< #{group}"
+    onData = (data) ->
+      received.push 'DATA'
+      check data
+    onEndGroup = (group) ->
+      received.push "> #{group}"
+      return unless received.length >= expected.length
+      socket.removeListener 'begingroup', onBeginGroup
+      socket.removeListener 'data', onData
+      socket.removeListener 'endgroup', onEndGroup
+      chai.expect(received).to.eql expected
+      done()
+    socket.on 'begingroup', onBeginGroup
+    socket.on 'data', onData
+    socket.on 'endgroup', onEndGroup
+
+  receiveAction = (socket, action, check, done) ->
+    expected = []
+    actionParts = action.split ':'
+    expected.push "< #{part}" for part in actionParts
+    expected.push 'DATA'
+    actionParts.reverse()
+    expected.push "> #{part}" for part in actionParts
+    receive socket, expected, check, done
+
+  receivePass = (socket, action, payload, done) ->
+    check = (data) ->
+      # Strict equality check for passed packets
+      chai.expect(data).to.equal payload
+    receiveAction socket, action, check, done
 
   # Set up a fake runtime connection and test that we can play both ends
   it 'should be able to connect', (done) ->
@@ -41,3 +112,28 @@ describe 'Runtime Middleware', ->
           send 'runtime', 'runtime',
             capabilities: capabilities
       , 100
+
+  describe 'receiving a runtime:connected action', ->
+    it 'should pass it out as-is', (done) ->
+      action = 'runtime:connected'
+      payload = runtime
+      receivePass passAction, action, payload, done
+      send actionIn, action, payload
+  describe 'receiving a context:edges action', ->
+    it 'should send selected edges to the runtime', (done) ->
+      expectedEdges = [
+        from:
+          node: 'Foo'
+          port: 'out'
+        to:
+          node: 'Bar'
+          port: 'in'
+      ]
+      send actionIn, 'context:edges',
+        graph: 'foo'
+        edges: expectedEdges
+      runtime.iframe.contentWindow.handleProtocolMessage (msg) ->
+        chai.expect(msg.protocol).to.equal 'network'
+        chai.expect(msg.command).to.equal 'edges'
+        chai.expect(msg.payload.edges).to.eql expectedEdges
+        done()

--- a/spec/RuntimeMiddleware.coffee
+++ b/spec/RuntimeMiddleware.coffee
@@ -1,0 +1,43 @@
+noflo = require 'noflo'
+
+unless noflo.isBrowser()
+  chai = require 'chai'
+  path = require 'path'
+  baseDir = path.resolve __dirname, '../'
+else
+  baseDir = 'noflo-ui'
+
+describe 'Runtime Middleware', ->
+  runtime = null
+  before (done) ->
+    fixtures = document.getElementById 'fixtures'
+    transport = require('fbp-protocol-client').getTransport 'iframe'
+    runtime = new transport
+      address: 'mockruntime.html'
+    runtime.setParentElement fixtures
+    window.runtime = runtime
+    done()
+
+  afterEach ->
+    runtime.iframe.contentWindow.clearMessages()
+
+  # Set up a fake runtime connection and test that we can play both ends
+  it 'should be able to connect', (done) ->
+    capabilities = [
+      'protocol:graph'
+      'protocol:component'
+      'protocol:network'
+      'protocol:runtime'
+    ]
+    runtime.connect()
+    runtime.once 'capabilities', (rtCapabilities) ->
+      chai.expect(rtCapabilities).to.eql capabilities
+      done()
+    runtime.iframe.addEventListener 'load', ->
+      setTimeout ->
+        runtime.iframe.contentWindow.handleProtocolMessage (msg, send) ->
+          chai.expect(msg.protocol).to.equal 'runtime'
+          chai.expect(msg.command).to.equal 'getruntime'
+          send 'runtime', 'runtime',
+            capabilities: capabilities
+      , 100

--- a/spec/UrlMiddleware.coffee
+++ b/spec/UrlMiddleware.coffee
@@ -37,10 +37,12 @@ describe 'URL Middleware', ->
   after ->
     window.location.hash = ''
 
-  send = (socket, action, payload) ->
+  send = (socket, action, payload, state) ->
     actionParts = action.split ':'
     socket.beginGroup part for part in actionParts
-    socket.send payload
+    socket.send
+      payload: payload
+      state: state
     socket.endGroup part for part in actionParts
     
   receive = (socket, expected, check, done) ->
@@ -49,7 +51,7 @@ describe 'URL Middleware', ->
       received.push "< #{group}"
     onData = (data) ->
       received.push 'DATA'
-      check data
+      check data.payload
     onEndGroup = (group) ->
       received.push "> #{group}"
       return unless received.length >= expected.length

--- a/spec/UserMiddleware.coffee
+++ b/spec/UserMiddleware.coffee
@@ -43,10 +43,12 @@ describe 'User Middleware', ->
     c.outPorts.pass.detach passAction
     c.outPorts.new.detach newAction
 
-  send = (socket, action, payload) ->
+  send = (socket, action, payload, state) ->
     actionParts = action.split ':'
     socket.beginGroup part for part in actionParts
-    socket.send payload
+    socket.send
+      payload: payload
+      state: state
     socket.endGroup part for part in actionParts
     
   receive = (socket, expected, check, done) ->
@@ -55,7 +57,7 @@ describe 'User Middleware', ->
       received.push "< #{group}"
     onData = (data) ->
       received.push 'DATA'
-      check data
+      check data.payload
     onEndGroup = (group) ->
       received.push "> #{group}"
       return unless received.length >= expected.length

--- a/spec/browser/EditGraph.coffee
+++ b/spec/browser/EditGraph.coffee
@@ -99,11 +99,13 @@ describe 'Editing a graph', ->
       chai.expect(context).to.exist
       results = context.shadowRoot.querySelector 'noflo-search-library-results'
       chai.expect(results).to.exist
-      getelement = results.shadowRoot.querySelector 'li'
-      chai.expect(getelement).to.exist
-      Syn.click getelement
       setTimeout ->
-        nodes = graph.shadowRoot.querySelectorAll 'g.nodes g.node'
-        chai.expect(nodes.length).to.equal 1
-        done()
-      , 3000
+        getelement = results.shadowRoot.querySelector 'li'
+        chai.expect(getelement).to.exist
+        Syn.click getelement
+        setTimeout ->
+          nodes = graph.shadowRoot.querySelectorAll 'g.nodes g.node'
+          chai.expect(nodes.length).to.equal 1
+          done()
+        , 3000
+      , 10

--- a/spec/mockruntime.html
+++ b/spec/mockruntime.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script>
+     var received = [];
+     window.addEventListener('message', function (message) {
+       var data;
+       if (typeof message.data === 'string') {
+         data = JSON.parse(message.data);
+       } else {
+         data = message.data;
+       }
+       if (!data.protocol || !data.command) {
+         return;
+       }
+       data.origin = message.origin;
+       received.push(data);
+     });
+     window.handleProtocolMessage = function (callback) {
+       if (!received.length) {
+         callback(null);
+       }
+       var msg = received.shift();
+       callback(msg, function (protocol, command, payload) {
+         console.log("SEND", protocol, command, payload, msg.origin);
+         window.parent.postMessage(JSON.stringify({
+           protocol: protocol,
+           command: command,
+           payload: payload
+         }), msg.origin);
+       });
+     };
+     window.clearMessages = function () {
+       received = [];
+     };
+    </script>
+  </body>
+</html>

--- a/spec/mockruntime.html
+++ b/spec/mockruntime.html
@@ -16,22 +16,33 @@
        if (!data.protocol || !data.command) {
          return;
        }
-       data.origin = message.origin;
        received.push(data);
      });
-     window.handleProtocolMessage = function (callback) {
-       if (!received.length) {
-         callback(null);
-       }
-       var msg = received.shift();
-       callback(msg, function (protocol, command, payload) {
-         console.log("SEND", protocol, command, payload, msg.origin);
+     window.sendProtocolMessage = function (protocol, command, payload) {
+       // Simulate some network delay
+       setTimeout(function () {
          window.parent.postMessage(JSON.stringify({
            protocol: protocol,
            command: command,
            payload: payload
-         }), msg.origin);
-       });
+         }), window.parent.location.href);
+       }, Math.ceil(Math.random() * 10));
+     };
+     window.handleProtocolMessage = function (callback, retried) {
+       if (!received.length) {
+         if (!retried) {
+           setTimeout(function () {
+             window.handleProtocolMessage(callback, true)
+           }, 10);
+           return;
+         }
+         callback(null);
+         return;
+       }
+       var msg = received.shift();
+       setTimeout(function () {
+         callback(msg, window.sendProtocolMessage);
+       }, 1);
      };
      window.clearMessages = function () {
        received = [];


### PR DESCRIPTION
Improves runtime handling reliability following the same middleware approach as we did with users in #660.

* [x] Sending selected edges to the runtime #328  (see also flowbased/fbp-protocol#31)
* [x] Send application state with actions to ensure right things are communicated with the right runtime

This PR will change actions from `payload` to `{ state: stateWhenActionFired, payload: payload }`. Will make compatibility wrapper so that old stores don't need to be touched.