### PR TITLE
Hide examples that require SSL when not on HTTPS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ NoFlo UI ChangeLog
 
 # 0.16.0 (git master)
 
+Bugfixes:
+
+* Examples that require SSL connection are no longer listed when on HTTP
+
 # 0.15.0 (2017 February 15)
 
 Bugfixes

--- a/elements/noflo-main.html
+++ b/elements/noflo-main.html
@@ -463,6 +463,9 @@
               var examples = runtimeInfo[runtime.type].examples;
 
               Object.keys(examples).forEach(function (key) {
+                if (examples[key].ssl && location.protocol !== 'https:') {
+                  return;
+                }
                 if (!examplesFound[key]) {
                   this.examples.push(examples[key]);
                   examplesFound[key] = true;
@@ -483,6 +486,7 @@
         },function (err, runtimes) {
           button.classList.remove('fa-spin');
           if (err) {
+            addExamplesForRuntimes.bind(this)();
             return;
           }
           var found = [];

--- a/runtimeinfo/imgflo.yaml
+++ b/runtimeinfo/imgflo.yaml
@@ -1,6 +1,6 @@
 runtimetypes:
   imgflo:
-    shortname: 'Image Manipulation'
+    shortname: 'ImgFlo Image Manipulation'
     icon: picture-o
     description: 'Process images using GEGL'
     helpurl: 'https://github.com/jonnor/imgflo#readme'

--- a/runtimeinfo/javafbp.yaml
+++ b/runtimeinfo/javafbp.yaml
@@ -1,6 +1,6 @@
 runtimetypes:
   javafbp:
-    shortname: Java
+    shortname: JavaFBP
     icon: android
     description: 'Program Java and Android applications'
     helpurl: 'https://github.com/jonnor/javafbp-runtime#readme'

--- a/runtimeinfo/microflo.yaml
+++ b/runtimeinfo/microflo.yaml
@@ -1,6 +1,6 @@
 runtimetypes:
   microflo:
-    shortname: Microcontroller
+    shortname: MicroFlo Microcontroller Programming
     icon: lightbulb-o
     description: 'Program microcontrollers like Arduino'
     helpurl: 'https://github.com/jonnor/microflo#readme'

--- a/runtimeinfo/msgflo.yaml
+++ b/runtimeinfo/msgflo.yaml
@@ -1,6 +1,6 @@
 runtimetypes:
   msgflo:
-    shortname: Message Queuing
+    shortname: MsgFlo Message Queuing
     icon: cubes
     description: 'Message queue orchestration'
     helpurl: 'https://github.com/the-grid/msgflo#readme'

--- a/runtimeinfo/noflo.yaml
+++ b/runtimeinfo/noflo.yaml
@@ -104,12 +104,14 @@ examples:
   photobooth:
     label: 'Photo booth'
     id: '7804187'
+    ssl: true
   clock:
     label: 'Animated clock'
     id: '7135158'
   camtopalette:
     label: 'Cam to palette'
     id: '3c0ffdf17195649a2d57'
+    ssl: true
   canvas:
     label: 'Canvas pattern'
     id: '1319c76fe006fb34c9c9'
@@ -119,6 +121,7 @@ examples:
   delaunaymasks:
     label: 'Delaunay masks'
     id: 'f6d1141de2833e45fb3c'
+    ssl: true
   reacttodo:
     label: 'React TODO list'
     id: '1d42f66f5cc4614df935'

--- a/runtimeinfo/sndflo.yaml
+++ b/runtimeinfo/sndflo.yaml
@@ -1,6 +1,6 @@
 runtimetypes:
   sndflo:
-    shortname: 'Sound synthesis'
+    shortname: 'SndFlo Sound Synthesis'
     icon: music
     description: 'Create sound using SuperCollider'
     helpurl: 'https://github.com/jonnor/sndflo#readme'


### PR DESCRIPTION
Since we originally published the examples list the browser security policies have changed. For example GetUserMedia is only available on HTTPS.

This PR hides examples that only work under HTTPS when using HTTP.