### PR TITLE
Fix login

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 NoFlo UI ChangeLog
 ==================
 
-# (git master)
+# 0.16.1 (git master)
+
+Bugfixes
+
+* Fixed compatibility with latest GitHub OAuth implementation
 
 # 0.16.0 (2017 Feburary 17)
 

--- a/components/CheckTokenGrant.coffee
+++ b/components/CheckTokenGrant.coffee
@@ -1,3 +1,4 @@
+urlParser = require 'url'
 qs = require 'querystring'
 noflo = require 'noflo'
 
@@ -21,12 +22,12 @@ exports.getComponent = ->
     # Check the URL for a OAuth grant code
     unless typeof data.payload is 'string'
       return callback new Error 'URL must be a string'
-    [url, query] = data.payload.split '?'
-    unless query
+    url = urlParser.parse data.payload
+    unless url.query
       # No query params, pass out as-is
       out.pass.send data
       return callback()
-    queryParams = qs.parse query
+    queryParams = qs.parse url.query
     if queryParams.error and queryParams.error_description
       callback new Error queryParams.error_description
     unless queryParams.code

--- a/components/StoreUser.coffee
+++ b/components/StoreUser.coffee
@@ -1,4 +1,5 @@
 noflo = require 'noflo'
+urlParser = require 'url'
 
 downloadAvatar = (avatarUrl, callback) ->
   return callback null, null unless avatarUrl
@@ -18,14 +19,17 @@ downloadAvatar = (avatarUrl, callback) ->
   req.send()
 
 cleanUpUrl = (out, callback) ->
-  [url, query] = window.location.href.split '?'
-  return callback() unless query
+  url = urlParser.parse window.location.href
+  # Clear query params, if any
+  delete url.search
+  newUrl = urlParser.format url
+  return callback() if newUrl is url
   if window.history?.replaceState
     # We can manipulate URL without reloading page
-    window.history.replaceState {}, 'clear', window.location.pathname
+    window.history.replaceState {}, 'clear', url.pathname
     return callback()
   # Old-school redirect
-  out.send url
+  out.send newUrl
   do callback
   return
 

--- a/graphs/UserMiddleware.fbp
+++ b/graphs/UserMiddleware.fbp
@@ -26,6 +26,8 @@ ExchangeToken ERROR -> IN UserErrorAction
 GetRemoteUser USER -> USER StoreUser(ui/StoreUser)
 GetRemoteUser ERROR -> IN UserErrorAction
 StoreUser USER -> IN UserInfoAction
+# In some cases we need to clean up URL after user has been persisted by redirecting
+StoreUser REDIRECT -> IN ApplicationRedirectAction
 
 # No grant code in URL, try to load local user data
 CheckQuery PASS -> START LoadUser(ui/LoadUserData)

--- a/spec/UserMiddleware.coffee
+++ b/spec/UserMiddleware.coffee
@@ -254,7 +254,25 @@ describe 'User Middleware', ->
         mock = sinon.fakeServer.create()
       afterEach ->
         mock.restore()
-      it 'should perform a token exchange and update user information', (done) ->
+      it 'should perform a token exchange and update user information without state in URL', (done) ->
+        action = 'application:url'
+        payload = "https://app.flowhub.io?code=#{code}"
+        check = (data) ->
+          chai.expect(data['grid-user']).to.eql userData
+        receiveAction newAction, 'user:info', check, done
+        send actionIn, action, payload
+        mock.respondWith 'GET', "https://noflo-gate.herokuapp.com/authenticate/#{code}", (req) ->
+          req.respond 200,
+            'Content-Type': 'application/json'
+          , JSON.stringify
+            token: token
+        mock.respondWith 'GET', "https://api.flowhub.io/user", (req) ->
+          req.respond 200,
+            'Content-Type': 'application/json'
+          , JSON.stringify userData
+        do mock.respond
+        do mock.respond
+      it 'should perform a token exchange and update user information with state in URL', (done) ->
         action = 'application:url'
         payload = "https://app.flowhub.io?code=#{code}&state="
         check = (data) ->

--- a/spec/UserMiddleware.coffee
+++ b/spec/UserMiddleware.coffee
@@ -193,7 +193,7 @@ describe 'User Middleware', ->
         mock.restore()
       it 'should perform a token exchange and fail', (done) ->
         action = 'application:url'
-        payload = "https://app.flowhub.io?code=#{code}"
+        payload = "https://app.flowhub.io?code=#{code}&state="
         check = (data) ->
           chai.expect(data.message).to.contain 'bad_code_foo'
         receiveAction newAction, 'user:error', check, done
@@ -218,7 +218,7 @@ describe 'User Middleware', ->
         mock.restore()
       it 'should perform a token exchange and fail at user fetch', (done) ->
         action = 'application:url'
-        payload = "https://app.flowhub.io?code=#{code}"
+        payload = "https://app.flowhub.io?code=#{code}&state="
         check = (data) ->
           chai.expect(data.message).to.contain 'Bad Credentials'
         receiveAction newAction, 'user:error', check, done
@@ -256,7 +256,7 @@ describe 'User Middleware', ->
         mock.restore()
       it 'should perform a token exchange and update user information', (done) ->
         action = 'application:url'
-        payload = "https://app.flowhub.io?code=#{code}"
+        payload = "https://app.flowhub.io?code=#{code}&state="
         check = (data) ->
           chai.expect(data['grid-user']).to.eql userData
         receiveAction newAction, 'user:info', check, done


### PR DESCRIPTION
GitHub just changed their OAuth redirect, breaking our post-login URL cleanup flow. This PR:

* Fixes URL cleanup to remove all query params
* Skips the window reload on most modern browsers by using [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
* Moves the "hidden" redirect action (still there for older browsers) to a visible action