### PR TITLE
More runtime data

### DIFF
--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -29,6 +29,7 @@ exports.getComponent = ->
       specs: []
 
     for graph in data.payload.graphs
+      graph.name = graph.name.split('/').pop()
       graph.setProperties
         id: "#{project.id}/#{graph.properties?.id or graph.name}"
         project: project.id

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -28,7 +28,11 @@ exports.getComponent = ->
       components: []
       specs: []
 
-    for graph in data.payload.graphs
+    graphs = data.payload.graphs.slice 0
+    components = []
+    components.push data.payload.component if data.payload.component
+
+    for graph in graphs
       graph.name = graph.name.split('/').pop()
       graph.setProperties
         id: "#{project.id}/#{graph.properties?.id or graph.name}"
@@ -40,10 +44,10 @@ exports.getComponent = ->
       project.graphs.push graph
       out.graph.send graph
 
-    if data.payload.component
-      data.payload.component.project = project.id
-      project.components.push data.payload.component
-      out.component.send data.payload.component
+    for component in components
+      component.project = project.id
+      project.components.push component
+      out.component.send component
 
     # TODO: Discover components with project's namespace from runtime
 

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -1,6 +1,11 @@
 noflo = require 'noflo'
 uuid = require 'uuid'
 
+isComponentInProject = (namespace, component) ->
+  return true if componentName.indexOf('/') is -1
+  [library, component] = componentName.split '/'
+  return library is namespace
+
 fetchSources = (components, runtime, sources, callback) ->
   return callback null, sources unless components.length
   handleMessage = (msg) ->
@@ -24,9 +29,7 @@ fetchFromLibrary = (runtime, callback) ->
   return callback null, [] unless runtime.definition?.namespace
   return callback null, [] unless runtime.definition.components
   components = Object.keys(runtime.definition.components).filter (componentName) ->
-    return true if componentName.indexOf('/') is -1
-    [library, component] = componentName.split '/'
-    return library is runtime.definition.namespace
+    isComponentInProject runtime.definition.namespace, componentName
   fetchSources components, runtime, [], callback
 
 exports.getComponent = ->

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -1,6 +1,34 @@
 noflo = require 'noflo'
 uuid = require 'uuid'
 
+fetchSources = (components, runtime, sources, callback) ->
+  return callback null, sources unless components.length
+  handleMessage = (msg) ->
+    if msg.command is 'error'
+      callback msg.payload
+      return
+    if msg.command is 'source'
+      sources.push msg.payload
+      fetchSources components, runtime, sources, callback
+      return
+    # We got unrelated message, subscribe again
+    runtime.once 'component', handleMessage
+  runtime.once 'component', handleMessage
+  component = components.shift()
+  runtime.sendComponent 'getsource',
+    name: component
+
+fetchFromLibrary = (runtime, callback) ->
+  return callback null, [] unless runtime.isConnected()
+  return callback null, [] unless runtime.canDo 'component:getsource'
+  return callback null, [] unless runtime.definition?.namespace
+  return callback null, [] unless runtime.definition.components
+  components = Object.keys(runtime.definition.components).filter (componentName) ->
+    return true if componentName.indexOf('/') is -1
+    [library, component] = componentName.split '/'
+    return library is runtime.definition.namespace
+  fetchSources components, runtime, [], callback
+
 exports.getComponent = ->
   c = new noflo.Component
   c.inPorts.add 'in',
@@ -28,49 +56,54 @@ exports.getComponent = ->
       components: []
       specs: []
 
+    # Start with the data we already have
     graphs = data.payload.graphs.slice 0
     components = []
     components.push data.payload.component if data.payload.component
 
-    for graph in graphs
-      graph.name = graph.name.split('/').pop()
-      graph.setProperties
-        id: "#{project.id}/#{graph.properties?.id or graph.name}"
-        project: project.id
-      project.main = graph.properties.id unless project.main
-      project.name = graph.name unless project.name
-      if graph.properties?.environment?.type and not project.type
-        project.type = graph.properties.environment.type
-      project.graphs.push graph
-      out.graph.send graph
+    # Add components and graphs from library
+    fetchFromLibrary data.payload.runtime, (err, sources) ->
+      return callback err if err
+      graphs = graphs.concat sources.filter (c) -> c.language is 'json'
+      components = components.concat sources.filter (c) -> c.language isnt 'json'
 
-    for component in components
-      component.project = project.id
-      project.components.push component
-      out.component.send component
+      for graph in graphs
+        graph.name = graph.name.split('/').pop()
+        graph.setProperties
+          id: "#{project.id}/#{graph.properties?.id or graph.name}"
+          project: project.id
+        project.main = graph.properties.id unless project.main
+        project.name = graph.name unless project.name
+        if graph.properties?.environment?.type and not project.type
+          project.type = graph.properties.environment.type
+        project.graphs.push graph
+        out.graph.send graph
 
-    # TODO: Discover components with project's namespace from runtime
+      for component in components
+        component.project = project.id
+        project.components.push component
+        out.component.send component
 
-    # Associate runtime with project for auto-connecting
-    data.payload.runtime.definition.project = project.id
-    out.runtime.send data.payload.runtime.definition
+      # Associate runtime with project for auto-connecting
+      data.payload.runtime.definition.project = project.id
+      out.runtime.send data.payload.runtime.definition
 
-    out.project.send
-      id: project.id
-      name: project.name
-      type: project.type
-      main: project.main
+      out.project.send
+        id: project.id
+        name: project.name
+        type: project.type
+        main: project.main
 
-    # FIXME: Do in reducer
-    data.state.projects.push project
-    foundRuntime = data.state.runtimes.filter (rt) ->
-      rt.id is data.payload.runtime.definition.id
-    if foundRuntime.length
-      foundRuntime[0].project = project.id
-    else
-      data.state.runtimes.push data.payload.runtime.definition
+      # FIXME: Do in reducer
+      data.state.projects.push project
+      foundRuntime = data.state.runtimes.filter (rt) ->
+        rt.id is data.payload.runtime.definition.id
+      if foundRuntime.length
+        foundRuntime[0].project = project.id
+      else
+        data.state.runtimes.push data.payload.runtime.definition
 
-    # FIXME: Make an action
-    window.location.hash = "#project/#{encodeURIComponent(project.id)}/#{encodeURIComponent(project.main)}"
+      # FIXME: Make an action
+      window.location.hash = "#project/#{encodeURIComponent(project.id)}/#{encodeURIComponent(project.main)}"
 
-    do callback
+      do callback

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -5,7 +5,7 @@ fetchSources = (components, runtime, sources, callback) ->
   return callback null, sources unless components.length
   handleMessage = (msg) ->
     if msg.command is 'error'
-      callback msg.payload
+      callback new Error msg.payload.message
       return
     if msg.command is 'source'
       sources.push msg.payload

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -1,7 +1,7 @@
 noflo = require 'noflo'
 uuid = require 'uuid'
 
-isComponentInProject = (namespace, component) ->
+isComponentInProject = (namespace, componentName) ->
   return true if componentName.indexOf('/') is -1
   [library, component] = componentName.split '/'
   return library is namespace


### PR DESCRIPTION
Follow-up to #695: save all components and graphs from runtime that match the project's namespace