### PR TITLE
Separate project namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New features
 
 * It is now possible to copy a live mode session into a project with the _Edit as project_ button
 * Live mode was changed to be read only
+* Project namespace used as library identifier for components and graphs is now separately editable
 
 Bugfixes
 

--- a/components/ContextToRuntime.coffee
+++ b/components/ContextToRuntime.coffee
@@ -9,7 +9,7 @@ sendContext = (context, out) ->
     return
 
   if context.graphs?.length
-    sendGraph graph, context.runtime for graph in context.graphs
+    sendGraph null, graph, context.runtime for graph in context.graphs
     out.send context
     out.disconnect()
     return
@@ -18,12 +18,13 @@ sendContext = (context, out) ->
   out.disconnect()
 
 sendProject = (project, runtime) ->
+  namespace = project.namespace or project.id
   if project.components
-    sendComponent component, runtime for component in project.components
+    sendComponent namespace, component, runtime for component in project.components
   if project.graphs
-    sendGraph graph, runtime, project for graph in project.graphs
+    sendGraph namespace, graph, runtime, project for graph in project.graphs
 
-sendComponent = (component, runtime) ->
+sendComponent = (namespace, component, runtime) ->
   return unless component.code
 
   # Check for platform-specific components
@@ -36,11 +37,11 @@ sendComponent = (component, runtime) ->
   runtime.sendComponent 'source',
     name: component.name
     language: component.language
-    library: component.project or component.library
+    library: namespace
     code: component.code
     tests: component.tests
 
-sendGraph = (graph, runtime, project) ->
+sendGraph = (namespace, graph, runtime, project) ->
   if graph.properties.environment?.type
     return unless graph.properties.environment.type in ['all', runtime.definition.type]
 
@@ -50,7 +51,7 @@ sendGraph = (graph, runtime, project) ->
   runtime.sendGraph 'clear',
     id: graphId
     name: graph.name
-    library: graph.properties.project
+    library: namespace
     main: (not project or graph.properties.id is project.main)
     icon: graph.properties.icon or ''
     description: graph.properties.description or ''

--- a/elements/noflo-context.html
+++ b/elements/noflo-context.html
@@ -320,23 +320,11 @@
         }.bind(this));
       },
       libraryMatch: function (library, project) {
-        if (library === project.id) {
+        var namespace = project.namespace || project.id;
+        if (library === namespace) {
           return true;
         }
-        if (library === project.id.replace('noflo-')) {
-          return true;
-        }
-        if (!project.repo) {
-          return false;
-        }
-        var repoParts = project.repo.split('/');
-        if (repoParts.length !== 2) {
-          return false;
-        }
-        if (library === repoParts[1]) {
-          return true;
-        }
-        if (library === repoParts[1].replace('noflo-', '')) {
+        if (library === namespace.replace('noflo-')) {
           return true;
         }
         return false;

--- a/elements/noflo-main.html
+++ b/elements/noflo-main.html
@@ -412,6 +412,7 @@
         var project = {
           id: repoId,
           name: repo,
+          namespace: repoId,
           repo: repo,
           graphs: [],
           components: [],

--- a/elements/noflo-new-project.html
+++ b/elements/noflo-new-project.html
@@ -68,7 +68,7 @@
         this.fire('new', {
           id: this.projectId,
           name: this.name,
-          namespace: this.namespace,
+          namespace: this.produceNamespace(this.namespace),
           type: this.type,
           graphs: [],
           components: [],

--- a/elements/noflo-new-project.html
+++ b/elements/noflo-new-project.html
@@ -43,19 +43,13 @@
       detached: function () {
         document.getElementById('container').classList.remove('blur');
       },
+      produceNamespace: function (namespace) {
+        return namespace.toLowerCase().replace(/[\s\/\._]/g, '-').replace('--', '-').replace(/[^a-z0-9\-]/g, '');
+      },
       nameChanged: function () {
-        this.namespace = this.name.toLowerCase().replace(/[\s\/\._]/g, '-').replace('--', '-').replace(/[^a-z0-9\-]/g, '');
-        this.projectId = this.namespace;
-        var duplicates = [];
-        if (this.projects) {
-          duplicates = this.projects.filter(function (project) {
-            if (project.id === this.projectId || project.name == this.name) {
-              return true;
-            }
-            return false;
-          }.bind(this));
-        }
-        if (this.name && this.namespace && this.projectId && !duplicates.length) {
+        this.namespace = this.produceNamespace(this.name);
+        this.projectId = require('uuid').v4();
+        if (this.name && this.namespace && this.projectId) {
           this.canSend = true;
         } else {
           this.canSend = false;
@@ -72,9 +66,9 @@
           ga('send', 'event', 'button', 'click', 'newProject');
         }
         this.fire('new', {
-          id: this.projectId.replace(/[\/\s\.]/g, '-'),
+          id: this.projectId,
           name: this.name,
-          namespace: this.namespace.replace(/[\/\s\.]/g, '-'),
+          namespace: this.namespace,
           type: this.type,
           graphs: [],
           components: [],

--- a/elements/noflo-new-project.html
+++ b/elements/noflo-new-project.html
@@ -14,8 +14,8 @@
           <input type="text" value="{{ name }}" placeholder="My Cool Project" required>
         </label>
         <label>
-          Project name
-          <input type="text" value="{{ projectId }}" placeholder="my-project" autocapitalize="off" autocorrect="off" readonly>
+          Project namespace
+          <input type="text" value="{{ namespace }}" placeholder="my-project" autocapitalize="off" autocorrect="off" readonly>
         </label>
         <label>
           Primary Type
@@ -32,6 +32,7 @@
     Polymer('noflo-new-project', {
       projectId: '',
       name: '',
+      namespace: '',
       type: 'noflo-browser',
       runtimes: null,
       projects: null,
@@ -43,7 +44,8 @@
         document.getElementById('container').classList.remove('blur');
       },
       nameChanged: function () {
-        this.projectId = this.name.toLowerCase().replace(/[\s\/\._]/g, '-').replace('--', '-').replace(/[^a-z0-9\-]/g, '');
+        this.namespace = this.name.toLowerCase().replace(/[\s\/\._]/g, '-').replace('--', '-').replace(/[^a-z0-9\-]/g, '');
+        this.projectId = this.namespace;
         var duplicates = [];
         if (this.projects) {
           duplicates = this.projects.filter(function (project) {
@@ -53,7 +55,7 @@
             return false;
           }.bind(this));
         }
-        if (this.name && this.projectId && !duplicates.length) {
+        if (this.name && this.namespace && this.projectId && !duplicates.length) {
           this.canSend = true;
         } else {
           this.canSend = false;
@@ -63,7 +65,7 @@
         if (event) {
           event.preventDefault();
         }
-        if (!this.name || !this.projectId) {
+        if (!this.name || !this.namespace || !this.projectId) {
           return;
         }
         if (typeof ga === 'function') {
@@ -72,6 +74,7 @@
         this.fire('new', {
           id: this.projectId.replace(/[\/\s\.]/g, '-'),
           name: this.name,
+          namespace: this.namespace.replace(/[\/\s\.]/g, '-'),
           type: this.type,
           graphs: [],
           components: [],

--- a/elements/noflo-project-inspector.html
+++ b/elements/noflo-project-inspector.html
@@ -25,6 +25,10 @@
           <input type="text" value="{{ name }}" placeholder="My Cool Project" required>
         </label>
         <label>
+          <span>Project namespace</span>
+          <input type="text" value="{{ namespace }}" placeholder="my-cool-project" required>
+        </label>
+        <label>
           <span>Main graph</span>
           <select name="type" value="{{ main }}">
             <template repeat="{{ graph in project.graphs }}">
@@ -50,6 +54,7 @@
       originalRepo: '',
       repo: '',
       name: '',
+      namespace: '',
       main: '',
       attached: function () {
         document.getElementById('container').classList.add('blur');
@@ -61,6 +66,7 @@
         this.originalRepo = this.project.repo;
         this.repo = this.project.repo;
         this.name = this.project.name;
+        this.namespace = this.project.namespace || this.project.id;
         this.main = this.project.main;
       },
       createProject: function (callback) {
@@ -94,6 +100,7 @@
         this.fire('updated', {
           id: this.project.id,
           name: this.name,
+          namespace: this.namespace,
           main: this.main,
           type: type,
           repo: this.repo

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -277,6 +277,7 @@
           this.fire('changed', {
             id: this.project.id,
             name: this.project.name,
+            namespace: this.project.namespace,
             repo: this.project.repo,
             type: this.project.type,
             main: this.project.main,

--- a/spec/browser/CreateProject.coffee
+++ b/spec/browser/CreateProject.coffee
@@ -73,7 +73,7 @@ describe 'Project Creation Dialog', ->
       submit = dialog.shadowRoot.querySelector '.toolbar button'
       Syn.click submit
       setTimeout ->
-        chai.expect(win.location.hash.indexOf('project/foo')).to.not.equal -1
+        chai.expect(win.location.hash.indexOf('project/')).to.not.equal -1
         done()
       , 1800
     it 'should have closed the dialog', ->


### PR DESCRIPTION
Follow-up to #700, separate project namespace (used as the library identifier when communicating with runtimes) from project ID. Allows editing the project namespace, as well as multiple checkouts of same project inside same Flowhub instance.