### PR TITLE
Make live mode read-only

### DIFF
--- a/elements/noflo-context.html
+++ b/elements/noflo-context.html
@@ -4,7 +4,7 @@
 <link rel="import" href="noflo-group-inspector.html">
 <link rel="import" href="the-card.html">
 <link rel="import" href="the-panel.html">
-<polymer-element name="noflo-context" attributes="project graphs component node edge search">
+<polymer-element name="noflo-context" attributes="project graphs component node edge search readonly">
   <template>
     <style>
       #context {
@@ -74,51 +74,23 @@
         if (!this.editor) {
           return;
         }
-        this.editor.addMenuAction('graphInport', 'n4', {
-          icon: 'pencil-square-o',
-          iconLabel: 'rename',
-          action: function (graph, itemKey, item) {
-            var dialog = document.createElement('noflo-exported-inspector');
-            dialog.graph = this.graphs[this.graphs.length - 1];
-            dialog.publicport = itemKey;
-            dialog.privateport = item;
-            dialog.direction = 'input';
-            document.body.appendChild(dialog);
-          }.bind(this)
-        });
-        this.editor.addMenuAction('graphOutport', 'n4', {
-          icon: 'pencil-square-o',
-          iconLabel: 'rename',
-          action: function (graph, itemKey, item) {
-            var dialog = document.createElement('noflo-exported-inspector');
-            dialog.graph = this.graphs[this.graphs.length - 1];
-            dialog.publicport = itemKey;
-            dialog.privateport = item;
-            dialog.direction = 'output';
-            document.body.appendChild(dialog);
-          }.bind(this)
-        });
-        this.editor.addMenuAction('selection', 'e4', {
-          icon: 'sitemap',
-          iconLabel: 'graph',
-          action: this.subgraph.bind(this)
-        });
-        this.editor.addMenuAction('selection', 'w4', {
-          icon: 'square-o',
-          iconLabel: 'group',
-          action: this.group.bind(this)
-        });
+        var emptyOnReadOnly = function (defaultMenu, options) {
+          if (this.readonly) {
+            return {};
+          }
+          return defaultMenu;
+        }.bind(this);
+        this.editor.addMenuCallback('main', emptyOnReadOnly);
+        this.editor.addMenuCallback('edge', emptyOnReadOnly);
         this.editor.addMenuCallback('node', function (defaultMenu, options) {
+          var localMenu = emptyOnReadOnly(defaultMenu, options);
           if (!options.item.component) {
-            return defaultMenu;
+            return localMenu;
           }
           if (!this.canGetSource(options.item.component)) {
-            return defaultMenu;
+            return localMenu;
           }
-          var i, menuKey;
-          var localMenu = {};
-          var project = this.project;
-          var openAction =  {
+          localMenu.n4 = {
             icon: 'arrow-circle-o-up',
             iconLabel: 'open',
             action: function (graph, itemKey, item) {
@@ -130,11 +102,62 @@
               window.location.hash = hash + '/' + encodeURIComponent(item.id);
             }
           };
-          for (menuKey in defaultMenu) {
-            localMenu[menuKey] = defaultMenu[menuKey];
-          }
-          localMenu.n4 = openAction;
           return localMenu;
+        }.bind(this));
+        this.editor.addMenuCallback('nodeInport', emptyOnReadOnly);
+        this.editor.addMenuCallback('nodeOutport', emptyOnReadOnly);
+        this.editor.addMenuCallback('graphInport', function (defaultMenu, options) {
+          if (this.readonly) {
+            return emptyOnReadOnly(defaultMenu, options);
+          }
+          defaultMenu.n4 = {
+            icon: 'pencil-square-o',
+            iconLabel: 'rename',
+            action: function (graph, itemKey, item) {
+              var dialog = document.createElement('noflo-exported-inspector');
+              dialog.graph = this.graphs[this.graphs.length - 1];
+              dialog.publicport = itemKey;
+              dialog.privateport = item;
+              dialog.direction = 'input';
+              document.body.appendChild(dialog);
+            }.bind(this)
+          };
+          return defaultMenu;
+        }.bind(this));
+        this.editor.addMenuCallback('graphOutport', function (defaultMenu, options) {
+          if (this.readonly) {
+            return emptyOnReadOnly(defaultMenu, options);
+          }
+          defaultMenu.n4 = {
+            icon: 'pencil-square-o',
+            iconLabel: 'rename',
+            action: function (graph, itemKey, item) {
+              var dialog = document.createElement('noflo-exported-inspector');
+              dialog.graph = this.graphs[this.graphs.length - 1];
+              dialog.publicport = itemKey;
+              dialog.privateport = item;
+              dialog.direction = 'output';
+              document.body.appendChild(dialog);
+            }.bind(this)
+          };
+          return defaultMenu;
+        }.bind(this));
+        this.editor.addMenuCallback('group', emptyOnReadOnly);
+        this.editor.addMenuCallback('selection', function (defaultMenu, options) {
+          if (this.readonly) {
+            return emptyOnReadOnly(defaultMenu, options);
+          }
+          defaultMenu.e4 = {
+            icon: 'sitemap',
+            iconLabel: 'graph',
+            action: this.subgraph.bind(this)
+          };
+          defaultMenu.w4 = {
+            icon: 'square-o',
+            iconLabel: 'group',
+            action: this.group.bind(this)
+          };
+          return defaultMenu;
         }.bind(this));
       },
       edgesChanged: function () {
@@ -156,6 +179,9 @@
         this.edges.splice(0, this.edges.length);
       },
       group: function (graph, itemKey, item) {
+        if (this.readonly) {
+          return;
+        }
         if (typeof ga === 'function') {
           ga('send', 'event', 'menu', 'click', 'createGroup');
         }
@@ -183,7 +209,7 @@
         document.body.appendChild(dialog);
       },
       subgraph: function (currentGraph, itemKey, item) {
-        if (!this.project) {
+        if (!this.project || this.readonly) {
           return;
         }
 

--- a/elements/noflo-context.html
+++ b/elements/noflo-context.html
@@ -1,4 +1,3 @@
-<link rel="import" href="noflo-node-inspector.html">
 <link rel="import" href="noflo-exported-inspector.html">
 <link rel="import" href="noflo-new-graph.html">
 <link rel="import" href="noflo-group-inspector.html">

--- a/elements/noflo-packets.html
+++ b/elements/noflo-packets.html
@@ -127,7 +127,14 @@
         this.logs[id] = new CircularBuffer(40);
       },
       showEdgeCards: function () {
-        if (!this.edgeMenu) {
+        if (this.edgeMenu) {
+          if (this.readonly) {
+            this.edgeMenu.parentNode.removeChild(this.edgeMenu);
+            this.edgeMenu = null;
+          } else {
+            this.edgeMenu.dialog.edges = this.edges;
+          }
+        } else if (!this.readonly) {
           var menu = document.createElement('noflo-edge-menu');
           menu.edges = this.edges;
           menu.graph = this.currentgraph;
@@ -136,8 +143,6 @@
           this.edgeMenu.dialog = menu;
           this.edgeMenu.appendChild(menu);
           this.edgeMenu.addTo(this.panel);
-        } else {
-          this.edgeMenu.dialog.edges = this.edges;
         }
 
         this.edges.forEach(function (edge) {
@@ -199,6 +204,9 @@
         this.nodes.forEach(function (node) {
           var id = node.id;
           if (this.nodeInspectors[id]) {
+            return;
+          }
+          if (this.readonly) {
             return;
           }
           this.ensureErrorLog(id);

--- a/elements/noflo-packets.html
+++ b/elements/noflo-packets.html
@@ -1,6 +1,7 @@
+<link rel="import" href="noflo-node-inspector.html">
 <link rel="import" href="noflo-edge-menu.html">
 <link rel="import" href="noflo-edge-inspector.html">
-<polymer-element name="noflo-packets">
+<polymer-element name="noflo-packets" attributes="readonly">
 <script>
   (function () {
     function CircularBuffer(n, clearCallback) {

--- a/elements/noflo-search.html
+++ b/elements/noflo-search.html
@@ -4,7 +4,7 @@
 <link rel="import" href="noflo-graph-inspector.html">
 <link rel="import" href="noflo-component-inspector.html">
 
-<polymer-element name="noflo-search" class="gpu" attributes="editor results graphs component">
+<polymer-element name="noflo-search" class="gpu" attributes="editor results graphs component readonly">
   <template>
     <style>
       :host {
@@ -165,7 +165,7 @@
 
     </style>
     <div id="breadcrumb" on-click="{{ focus }}">
-      <template if="{{ !component || !component.name }}">
+      <template if="{{ !readonly && (!component || !component.name) }}">
       <i class="fa fa-search"></i>
       </template>
       <h1 title="Search">
@@ -179,13 +179,13 @@
         {{ component.name }}
         </template>
       </h1>
-      <template if="{{ graph && (!component || !component.name) }}">
+      <template if="{{ !readonly && graph && (!component || !component.name) }}">
       <button on-click="{{ showGraphInspector }}" id="graphinspector" title="Graph properties"><i class="fa fa-cog"></i></button>
       </template>
-      <template if="{{ !graph && component && component.name }}">
+      <template if="{{ !readonly && !graph && component && component.name }}">
       <button on-click="{{ showComponentInspector }}" id="componentinspector" title="Component properties"><i class="fa fa-cog"></i></button>
       </template>
-      <template if="{{ (component && component.readonly) || (graph && graph.properties.readonly) }}">
+      <template if="{{ readonly || (component && component.readonly) || (graph && graph.properties.readonly) }}">
       <i id="readonly" class="fa fa-lock"></i>
       </template>
     </div>
@@ -268,6 +268,9 @@
         this.blur();
       },
       focus: function () {
+        if (this.readonly) {
+          return;
+        }
         if (this.component && this.component.name) {
           return;
         }

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -389,14 +389,16 @@
             this.$.asproject.style.visibility = 'visible';
             this.$.asproject.style.opacity = 1;
             this.$.grapheditor.readonly = true;
-            this.$.search.readonly = true;
             this.$.context.readonly = true;
+            this.$.packets.readonly = true;
+            this.$.search.readonly = true;
           } else {
             this.$.asproject.style.visibility = 'hidden';
             this.$.asproject.style.opacity = 0;
             this.$.grapheditor.readonly = false;
-            this.$.search.readonly = false;
             this.$.context.readonly = false;
+            this.$.packets.readonly = false;
+            this.$.search.readonly = false;
           }
         } else {
           this.$.main.open = true;

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -388,9 +388,11 @@
           if (!this.ctx.project) {
             this.$.asproject.style.visibility = 'visible';
             this.$.asproject.style.opacity = 1;
+            this.$.grapheditor.readonly = true;
           } else {
             this.$.asproject.style.visibility = 'hidden';
             this.$.asproject.style.opacity = 0;
+            this.$.grapheditor.readonly = false;
           }
         } else {
           this.$.main.open = true;

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -389,10 +389,12 @@
             this.$.asproject.style.visibility = 'visible';
             this.$.asproject.style.opacity = 1;
             this.$.grapheditor.readonly = true;
+            this.$.search.readonly = true;
           } else {
             this.$.asproject.style.visibility = 'hidden';
             this.$.asproject.style.opacity = 0;
             this.$.grapheditor.readonly = false;
+            this.$.search.readonly = false;
           }
         } else {
           this.$.main.open = true;

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -390,11 +390,13 @@
             this.$.asproject.style.opacity = 1;
             this.$.grapheditor.readonly = true;
             this.$.search.readonly = true;
+            this.$.context.readonly = true;
           } else {
             this.$.asproject.style.visibility = 'hidden';
             this.$.asproject.style.opacity = 0;
             this.$.grapheditor.readonly = false;
             this.$.search.readonly = false;
+            this.$.context.readonly = false;
           }
         } else {
           this.$.main.open = true;


### PR DESCRIPTION
Now that we have the "edit as project" feature (#695), this PR makes live mode read-only.

* [x] Disable graph editor menu actions that manipulate graph
* [x] Disable IIP editing
* [x] Disable edge editing
* [x] Disable component search / adding nodes
* [x] Pass readonly flag to graph editor

Note that when you open a node via context menu, there is no back button shown in the search area (as reported in #369). Browser back button works.