### PR TITLE
Update NoFlo component examples to Process API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ New features
 
 * It is now possible to copy a live mode session into a project with the _Edit as project_ button
 * Live mode was changed to be read only
+* Updated NoFlo component examples to the [0.8 Process API](https://noflojs.org/documentation/components/)
 
 Bugfixes
 

--- a/runtimeinfo/noflo.yaml
+++ b/runtimeinfo/noflo.yaml
@@ -30,17 +30,19 @@ componenttemplates:
       c.outPorts.add('out', {
         datatype: 'all'
       });
-      noflo.helpers.WirePattern(c, {
-        "in": ['in'],
-        out: 'out',
-        forwardGroups: true,
-        async: true
-      }, function(data, groups, out, callback) {
-        // do something with data
-        // send output
-        out.send(data);
-        // tell WirePattern we are done
-        return callback();
+      c.process(function (input, output) {
+        // Check preconditions on input data
+        if (!input.hasData('in')) {
+          return;
+        }
+        // Read packets we need to process
+        var data = input.getData('in');
+        // Process data and send output
+        output.send({
+          out: data
+        });
+        // Deactivate
+        output.done();
       });
       return c;
     };
@@ -56,20 +58,16 @@ componenttemplates:
         description: 'Packet to forward'
       c.outPorts.add 'out',
         datatype: 'all'
-
-      noflo.helpers.WirePattern c,
-        in: ['in']
-        out: 'out'
-        forwardGroups: true
-        async: true
-      , (data, groups, out, callback) ->
-        # do something with data
-        # send it on outport
-        out.send data
-
-        # let WirePattern know we are done
-        do callback
-      c
+      c.process (input, output) ->
+        # Check preconditions on input data
+        return unless input.hasData 'in'
+        # Read packets we need to process
+        data = input.getData 'in'
+        # Process data and send output
+        output.send
+          out: data
+        # Deactivate
+        output.done()
 
   es2015: |
     import noflo from 'noflo';
@@ -85,17 +83,19 @@ componenttemplates:
       c.outPorts.add('out', {
         datatype: 'all'
       });
-      noflo.helpers.WirePattern(c, {
-        "in": ['in'],
-        out: 'out',
-        forwardGroups: true,
-        async: true
-      }, function(data, groups, out, callback) {
-        // do something with data
-        // send output
-        out.send(data);
-        // tell WirePattern we are done
-        return callback();
+      c.process(function (input, output) {
+        // Check preconditions on input data
+        if (!input.hasData('in')) {
+          return;
+        }
+        // Read packets we need to process
+        var data = input.getData('in');
+        // Process data and send output
+        output.send({
+          out: data
+        });
+        // Deactivate
+        output.done();
       });
       return c;
     };


### PR DESCRIPTION
NoFlo 0.8 has been out for quite a while. Time to update the component templates to [the new API](http://bergie.iki.fi/blog/noflo-process-api/)