### PR TITLE
Account redesign

### DIFF
--- a/elements/noflo-account.html
+++ b/elements/noflo-account.html
@@ -3,111 +3,66 @@
   <template>
     <style>
       :host {
-        text-align: center;
-        display: block;
         background-color: hsla(0, 0%, 0%, 0.98) !important;
-        padding-top: 36px;
-        padding-bottom: 72px;
-      }
-      section {
         display: block;
-        position: relative;
+        padding-top: 18px;
+        width: 100%;
+      }
+      nav {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
         padding-left: 72px;
         padding-right: 72px;
+        padding-bottom: 18px;
       }
-      section > h2 {
-        font-size: 17px;
+      section.app {
+        display: flex;
+        flex-direction: row;
+      }
+      section.app .logo {
+        margin-right: 18px;
+      }
+      section.app .logo img {
+        width: 72px;
+        height: 72px;
+        display: inline-block;
+      }
+      section.app h1 {
+        font-size: 18px;
         line-height: 36px;
-        margin-top: 36px;
-        height: 36px;
-        color: white;
-        text-shadow: 0 1px 0 hsl(185, 98%, 46%);
-        text-transform: none;
+        margin: 0;
+        padding: 0;
       }
-      .avatar {
-        border-radius: 50px;
-        background-color: black;
-        border: 2px solid hsl(185, 98%, 46%);
-        display: block;
-        position: relative;
-        width: 72px;
-        height: 72px;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 36px;
-        margin-bottom: 36px;
-        overflow: hidden;
-        box-sizing: border-box;
+      section.app h2 {
+        font-size: 9px;
+        line-height: 36px;
+        margin: 0;
+        padding: 0;
       }
-      .avatar:before {
-        content: '';
-        border: 3px solid black;
-        border-radius: 50px;
-        width: 70px;
-        height: 70px;
-        left: -1px;
-        top: -1px;
-        position: absolute;
-        z-index: 1;
-        box-sizing: border-box;
+      section.user {
+        text-align: right;
       }
-      .avatar.flowhub {
-        border-radius: 11px;
-        border: 1px solid hsl(185, 98%, 46%);
-      }
-      .avatar.noflo {
-        border: 1px solid hsl(185, 98%, 46%);
-      }
-      .avatar.flowhub:before {
-        border: none;
-        border-radius: 6px;
-        width: 72px;
-        height: 72px;
-      }
-      .avatar.noflo:before {
-        border: none;
-      }
-      .avatar img {
-        border: 2px solid hsl(185, 98%, 46%);
-        width: 66px;
-        height: 66px;
-        margin-top: 1px;
-        margin-left: 1px;
-        box-sizing: border-box;
-        border-radius: 50px;
-      }
-      .flowhub img {
-        width: 54px;
-        height: 53px;
-        padding: 6px;
-        margin-top: 8px;
-        border-radius: 6px;
-        box-sizing: border-box;
-      }
-      .noflo img {
-        width: 55px;
-        height: 22px;
-        border: none;
-        margin-top: 23px;
-        margin-left: 5px;
-        border-radius: initial;
-      }
-      h1 {
+      section.user .avatar {
+        display: inline;
         line-height: 18px;
-        margin: 0px;
-        padding: 0px;
-        position: relative;
       }
-      h1 form {
-        display: inline;
+      section.user .avatar img {
+        width: 18px;
+        height: 18px;
+        display: inline-block;
       }
-      #plan {
+      section.user h1,
+      section.user form {
         display: inline;
-        position: absolute;
+        line-height: 36px;
+      }
+      section.user #plan {
+        display: inline-block;
         font-size: 8px;
         text-transform: uppercase;
-        top: -8px;
-        margin-left: 8px;
+        vertical-align: super;
         color: black;
         background-color: hsl(185, 98%, 46%);
         border: none;
@@ -117,55 +72,79 @@
         border-radius: 2px;
         cursor: pointer;
       }
-      .toolbar {
-        margin-top: 54px;
-        padding: 1px;
-        border-radius: 3px;
-        border: 1px solid hsl(185, 98%, 46%);
-        color: hsl(185, 98%, 46%);
-        background-color: black;
-        display: inline-block;
-        box-sizing: border-box;
-        margin-bottom: -3px;
+      section.user .free #plan,
+      section.user .backer #plan {
+        background-color: hsl(135, 98%, 46%);
       }
-      .toolbar button,
-      .toolbar a.login {
-        background-color: hsla(185, 98%, 46%, .8);
-        color: hsla(0, 0%, 0%, 0.98);
-        border: none;
-        font-size: 13px;
-        border-radius: 3px;
-        font-family: "SourceCodePro",Helvetica,Arial,sans-serif;
-        height: 36px;
-        padding-left: 36px;
-        padding-right: 36px;
-        margin: 0px;
+      section.user .pro #plan {
+        background-color: hsl(160, 98%, 46%);
       }
-      .toolbar a {
-        font-size: 13px;
-        color: hsl(185, 98%, 46%);
-        text-decoration: none;
-        height: 36px;
-        display: inline-block;
+      section.user .supporter #plan {
+        background-color: hsl(185, 98%, 46%);
+      }
+      section.user .toolbar {
         line-height: 36px;
-        padding-left: 36px;
-        padding-right: 36px;
-        cursor: pointer;
+        font-size: 9px;
       }
-      .banner {
-        margin-top: 72px;
-        margin-bottom: -72px;
+      section.user .toolbar a,
+      section.user .toolbar button {
+        padding: 3px;
+        text-shadow: none;
+        text-decoration: none;
+        box-shadow: none;
+        font-family: "SourceCodePro",Helvetica,Arial,sans-serif;
+        font-size: 9px;
+        margin-left: 9px;
+        cursor: pointer;
+        border: none;
+        background-color: transparent;
+        color: white;
+      }
+      section.user .toolbar a.login::before {
+        content: ' ';
+        position: absolute;
+        border: 2px solid hsla(190, 98%, 46%, .8);
+        border-radius: 6px;
+        top: -6px;
+        bottom: -6px;
+        left: -6px;
+        right: -6px;
+        transition: all 0.3s ease;
+      }
+      section.user .toolbar a.login {
+        position: relative;
+        padding: 9px;
+        font-size: 18px;
+        border: 1px solid hsl(190, 98%, 46%);
+        background: hsla(190, 98%, 46%, .8);
+        line-height: 18px;
+        border-radius: 3px;
+        color: white;
+        font-family: "SourceCodePro",Helvetica,Arial,sans-serif;
+        box-sizing: border-box;
+        transition: background-color 0.2s ease-in;
+      }
+      section.user .toolbar a.login:hover,
+      section.user .toolbar a.login:focus,
+      section.user .toolbar a.login:active {
+        background-color: hsla(187, 31%, 6%, .4) !important;
+        color: white !important;
+        outline: 0;
+      }
+      div.banner {
         background-color: hsla(190, 98%, 46%, .8);
         padding: 18px;
+        padding-left: 72px;
+        padding-right: 72px;
       }
-      .banner a {
+      div.banner a {
         color: white;
         cursor: pointer;
       }
-      .banner div {
+      div.banner div {
         margin-top: 18px;
       }
-      .banner button, .banner input[type="submit"] {
+      div.banner button {
         display: inline-block;
         color: black;
         background-color: hsl(192, 25%, 92%);
@@ -179,25 +158,24 @@
         margin: 0px;
         cursor: pointer;
       }
-      /* Plan colors */
-      .free #plan,
-      .backer #plan {
-        background-color: hsl(135, 98%, 46%);
-      }
-      .pro #plan {
-        background-color: hsl(160, 98%, 46%);
-      }
-      .supporter #plan {
-        background-color: hsl(185, 98%, 46%);
-      }
     </style>
+    <nav>
+    <section class="app">
+      <div class="logo $NOFLO_THEME"><img src="../app/$NOFLO_THEME-72.png"></div>
+      <div class="name">
+      <h1>
+        $NOFLO_APP_NAME
+      </h1>
+      <h2>
+        v$NOFLO_APP_VERSION
+      </h2>
+      </div>
+    </section>
+    <section class="user">
     <template if="{{ user }}">
       <div class="{{ plan }}">
         <template if="{{ avatar }}">
-        <div class="avatar"><img src="{{ avatar }}"></div>
-        </template>
-        <template if="{{ !avatar }}">
-        <div class="avatar $NOFLO_THEME"><img src="../app/$NOFLO_THEME-logo-74.png"></div>
+          <div class="avatar"><img src="{{ avatar }}"></div>
         </template>
         <h1>
           {{ user.name }}
@@ -212,6 +190,15 @@
           <button on-click="{{ logout }}">Logout</button>
         </div>
       </div>
+    </template>
+    <template if="{{ !user }}">
+      <div class="toolbar">
+        <a id="loginbutton" class="login" on-click="{{ login }}">Login</a>
+      </div>
+    </template>
+    </section>
+    </nav>
+    <template if="{{ user }}">
       <template if="{{ askForScope.length }}">
         <div class="banner">
           To be able to synchronize your GitHub projects, $NOFLO_APP_TITLE needs repository access permissions. <a href="https://docs.flowhub.io/github-integration/" target="_blank">Read more</a>
@@ -242,11 +229,6 @@
       </template>
     </template>
     <template if="{{ !user }}">
-      <div class="avatar $NOFLO_THEME"><img src="../app/$NOFLO_THEME-logo-74.png"></div>
-      <h1>$NOFLO_APP_TITLE</h1>
-      <div class="toolbar">
-        <a id="loginbutton" class="login" on-click="{{ login }}">Login</a>
-      </div>
       <div class="banner">
         Logging into $NOFLO_APP_TITLE enables you to synchronize projects with Github. <a href="https://docs.flowhub.io/github-integration/" target="_blank">Read more</a>
       </div>

--- a/elements/noflo-account.html
+++ b/elements/noflo-account.html
@@ -186,6 +186,7 @@
           </form>
         </h1>
         <div class="toolbar">
+          <a href="https://docs.flowhub.io" target="_blank">Docs</a>
           <a on-click="{{ openSettings }}">Settings</a>
           <button on-click="{{ logout }}">Logout</button>
         </div>

--- a/elements/noflo-account.html
+++ b/elements/noflo-account.html
@@ -178,7 +178,7 @@
           <div class="avatar"><img src="{{ avatar }}"></div>
         </template>
         <h1>
-          {{ user.name }}
+          {{ user.github.username }}
           <form method="post" action="https://plans.flowhub.io/auth/flowhub">
             <input type="hidden" name="username" value="{{ user.github.username }}">
             <input type="hidden" name="password" value="{{ gridToken }}">


### PR DESCRIPTION
Redesign the accounts part of the main screen to take less space (112 vertical pixels compared to 361 on the old version).

* Show app name and version on the screen
* Show GitHub username instead of full name
* Show a help link in the toolbar

Here is how it looks for anonymous users:
![screenshot 2017-05-19 at 15 58 52](https://cloud.githubusercontent.com/assets/3346/26251018/343fb4ba-3cac-11e7-8535-51a14bfe2c97.png)

And for an authenticated user:
![screenshot 2017-05-19 at 15 58 37](https://cloud.githubusercontent.com/assets/3346/26251033/40e647f6-3cac-11e7-8ffc-d9b7ba13c706.png)

For reference, here is the previous design:
![screenshot 2017-05-19 at 16 00 50](https://cloud.githubusercontent.com/assets/3346/26251079/607ebdaa-3cac-11e7-94a0-4b8e304d5183.png)





