### PR TITLE
Bundle Polymer elements from the-graph

### DIFF
--- a/elements/noflo-journal.html
+++ b/elements/noflo-journal.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../node_modules/the-graph/the-graph-nav/the-graph-nav.html">
+<link rel="import" href="the-graph-nav.html">
 
 <polymer-element name="noflo-journal" attributes="graph editor panel">
   <template>

--- a/elements/noflo-main.html
+++ b/elements/noflo-main.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../node_modules/the-graph/the-graph-thumb/the-graph-thumb.html">
+<link rel="import" href="the-graph-thumb.html">
 <link rel="import" href="noflo-anonymous.html">
 <link rel="import" href="noflo-account.html">
 <link rel="import" href="noflo-new-project.html">

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -1,5 +1,5 @@
 <link rel="import" href="the-panel.html">
-<link rel="import" href="../node_modules/the-graph/the-graph-thumb/the-graph-thumb.html">
+<link rel="import" href="the-graph-thumb.html">
 <link rel="import" href="noflo-new-graph.html">
 <link rel="import" href="noflo-new-component.html">
 <link rel="import" href="noflo-project-inspector.html">

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -1,5 +1,5 @@
 <link rel="import" href="noflo-main.html">
-<link rel="import" href="../node_modules/the-graph/the-graph-editor/the-graph-editor.html">
+<link rel="import" href="the-graph-editor.html">
 <link rel="import" href="noflo-library.html">
 <link rel="import" href="noflo-context.html">
 <link rel="import" href="noflo-runtime.html">

--- a/elements/the-graph-editor.html
+++ b/elements/the-graph-editor.html
@@ -1,0 +1,192 @@
+<link rel="import" href="the-graph.html">
+
+<polymer-element name="the-graph-editor" attributes="grid snap width height autolayout theme selectedNodes errorNodes selectedEdges animatedEdges onContextMenu displaySelectionGroup forceSelection readonly" touch-action="none">
+  <template>
+    <the-graph id="graph"
+      name="{{ graph.properties.name }}"
+      graph="{{graph}}"
+      menus="{{menus}}"
+      width="{{width}}" height="{{height}}"
+      pan="{{pan}}" scale="{{scale}}"
+      autolayout="{{autolayout}}"
+      readonly="{{readonly}}"
+      theme="{{theme}}"
+      selectedNodes="{{selectedNodes}}"
+      errorNodes="{{errorNodes}}"
+      selectedEdges="{{selectedEdges}}"
+      animatedEdges="{{animatedEdges}}"
+      displaySelectionGroup="{{displaySelectionGroup}}"
+      forceSelection="{{forceSelection}}"
+      getMenuDef="{{getMenuDef}}">
+    </the-graph>
+  </template>
+  <script>
+  (function () {
+    "use strict";
+
+    Polymer('the-graph-editor', {
+      graph: null,
+      grid: 72,
+      snap: 36,
+      width: 800,
+      height: 600,
+      scale: 1,
+      plugins: {},
+      menus: null,
+      autolayout: false,
+      theme: "dark",
+      selectedNodes: [],
+      copyNodes: [],
+      errorNodes: {},
+      selectedEdges: [],
+      animatedEdges: [],
+      displaySelectionGroup: true,
+      forceSelection: false,
+      created: function () {
+        this.pan = [0,0];
+        this.menus = TheGraph.editor.getDefaultMenus(this);
+      },
+      ready: function () {},
+      attached: function () {
+      },
+      detached: function () {
+        for (var name in this.plugins) {
+          this.plugins[name].unregister(this);
+          delete this.plugins[name];
+        }
+      },
+      addPlugin: function (name, plugin) {
+        this.plugins[name] = plugin;
+        plugin.register(this);
+      },
+      addMenu: function (type, options) {
+        // options: icon, label
+        this.menus[type] = options;
+      },
+      addMenuCallback: function (type, callback) {
+        if (!this.menus[type]) {
+          return;
+        }
+        this.menus[type].callback = callback;
+      },
+      addMenuAction: function (type, direction, options) {
+        if (!this.menus[type]) {
+          this.menus[type] = {};
+        }
+        var menu = this.menus[type];
+        menu[direction] = options;
+      },
+      getMenuDef: function (options) {
+        // Options: type, graph, itemKey, item
+        if (options.type && this.menus[options.type]) {
+          var defaultMenu = this.menus[options.type];
+          if (defaultMenu.callback) {
+            return defaultMenu.callback(defaultMenu, options);
+          }
+          return defaultMenu;
+        }
+        return null;
+      },
+      notifyViewChanged: function () {
+        var view = {
+          scale: this.scale,
+          pan: this.pan,
+          width: this.width,
+          height: this.height,
+        };
+        this.fire('viewchanged', view);
+      },
+      panChanged: function () {
+        this.notifyViewChanged();
+      },
+      scaleChanged: function () {
+        this.notifyViewChanged();
+      },
+      widthChanged: function () {
+        this.style.width = this.width + "px";
+        this.notifyViewChanged();
+      },
+      heightChanged: function () {
+        this.style.height = this.height + "px";
+        this.notifyViewChanged();
+      },
+      graphChanged: function () {
+        if (typeof this.graph.addNode !== 'function') {
+          throw new Error(".graph property of the-graph-editor must be a fbp-graph instance (since the-graph 0.8)");
+        }
+        this.buildInitialLibrary(this.graph);
+      },
+      buildInitialLibrary: function (graph) {
+        /*if (Object.keys(this.$.graph.library).length !== 0) {
+          // We already have a library, skip
+          // TODO what about loading a new graph? Are we making a new editor?
+          return;
+        }*/
+        var components = TheGraph.library.componentsFromGraph(graph);
+        components.forEach(function(component) {
+            this.registerComponent(component, true);
+        }.bind(this));
+      },
+      registerComponent: function (definition, generated) {
+        this.$.graph.registerComponent(definition, generated);
+      },
+      libraryRefresh: function () {
+        this.$.graph.debounceLibraryRefesh();
+      },
+      updateIcon: function (nodeId, icon) {
+        this.$.graph.updateIcon(nodeId, icon);
+      },
+      rerender: function () {
+        this.$.graph.rerender();
+      },
+      triggerAutolayout: function () {
+        this.$.graph.triggerAutolayout();
+      },
+      triggerFit: function () {
+        this.$.graph.triggerFit();
+      },
+      animateEdge: function (edge) {
+        // Make sure unique
+        var index = this.animatedEdges.indexOf(edge);
+        if (index === -1) {
+          this.animatedEdges.push(edge);
+        }
+      },
+      unanimateEdge: function (edge) {
+        var index = this.animatedEdges.indexOf(edge);
+        if (index >= 0) {
+          this.animatedEdges.splice(index, 1);
+        }
+      },
+      addErrorNode: function (id) {
+        this.errorNodes[id] = true;
+        this.updateErrorNodes();
+      },
+      removeErrorNode: function (id) {
+        this.errorNodes[id] = false;
+        this.updateErrorNodes();
+      },
+      clearErrorNodes: function () {
+        this.errorNodes = {};
+        this.updateErrorNodes();
+      },
+      updateErrorNodes: function () {
+        this.$.graph.errorNodesChanged();
+      },
+      focusNode: function (node) {
+        this.$.graph.focusNode(node);
+      },
+      getComponent: function (name) {
+        return this.$.graph.getComponent(name);
+      },
+      getLibrary: function () {
+        return this.$.graph.library;
+      },
+      toJSON: function () {
+        return this.graph.toJSON();
+      }
+    });
+
+  })();
+  </script>
+</polymer-element>

--- a/elements/the-graph-nav.html
+++ b/elements/the-graph-nav.html
@@ -1,0 +1,161 @@
+<!-- 
+  
+* Wraps the-graph-thumb with a current view bounding box
+* Observes changes from attached instance of the-graph-editor
+
+-->
+
+<link rel="import" href="the-graph-thumb.html">
+
+<polymer-element name="the-graph-nav" attributes="width height graph theme hide" touch-action="none">
+  <template>
+    <style>
+      #thumb, 
+      #outcanvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        overflow: visible;
+      }
+      #viewrect {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 200px;
+        height: 150px;
+        border: 1px solid hsla(190, 100%, 80%, 0.4);
+        border-style: dotted;
+      }
+    </style>
+    <the-graph-thumb id="thumb"
+      graph="{{ graph }}"
+      thumbrectangle="{{thumbrectangle}}"
+      width="{{width}}" height="{{height}}"
+      thumbscale="{{thumbscale}}"
+      hide="{{hide}}"
+      theme="{{ theme }}">
+    </the-graph-thumb>
+    <canvas id="outcanvas" width="{{width}}" height="{{height}}" style="position:absolute;top:0;left:0;"></canvas>
+    <div id="viewrect"></div>
+  </template>
+  <script>
+  (function () {
+    "use strict";
+
+    Polymer('the-graph-nav', {
+      width: 200,
+      height: 150,
+      hide: false,
+      thumbscale: 1,
+      backgroundColor: "hsla(184, 8%, 75%, 0.9)",
+      outsideFill: "hsla(0, 0%, 0%, 0.4)",
+      ready: function () {
+        this.viewrectangle = [0,0,500,500];
+        this.scaledviewrectangle = [0,0,200,150];
+        this.theme = "dark";
+      },
+      attached: function () {
+        this.style.overflow = "hidden";
+        this.style.cursor = "move";
+        this.style.width = this.width + "px";
+        this.style.height = this.height + "px";
+
+        // HACK way to make PolymerGestures work for now
+        var noop = function(){};
+        PolymerGestures.addEventListener(this, "track", noop);
+        PolymerGestures.addEventListener(this, "trackend", noop);
+        PolymerGestures.addEventListener(this, "tap", noop);
+
+        // Pan graph by dragging map
+        this.addEventListener("track", function (event) {
+          // Don't pan underlying elements
+          event.stopPropagation();
+
+          var x = -this.viewrectangle[0];
+          var y = -this.viewrectangle[1];
+          var panscale = this.thumbscale / this.scale;
+          x -= event.ddx / panscale;
+          y -= event.ddy / panscale;
+          var panTo = { x: Math.round(x), y: Math.round(y) };
+          // Update our estimates locally, since update from outside might be delayed
+          this.viewrectangle[0] = -panTo.x;
+          this.viewrectangle[1] = -panTo.y;
+          this.fire('panto', panTo);
+
+          event.preventTap();
+        }.bind(this));
+        this.addEventListener("trackend", function (event) {
+          // Don't pan graph
+          event.stopPropagation();
+        }.bind(this));
+
+        // Tap to fit
+        this.addEventListener("tap", function () {
+          this.fire('triggerfit');
+        });
+      },
+      viewChanged: function (view) {
+        if (!view) {
+            return;
+        }
+        var x = view.pan[0];
+        var y = view.pan[1];
+
+        this.viewrectangle[0] = -x;
+        this.viewrectangle[1] = -y;
+        this.viewrectangle[2] = view.width;
+        this.viewrectangle[3] = view.height;
+
+        this.scale = view.scale;
+      },
+      themeChanged: function () {
+        var style = TheGraph.nav.calculateStyleFromTheme(this.theme);
+        this.backgroundColor = style.backgroundColor;
+        this.viewBoxBorder = style.viewBoxBorder;
+        this.viewBoxBorder2 = style.viewBoxBorder2;
+        this.outsideFill = style.outsideFill;
+        this.style.backgroundColor = this.backgroundColor;
+        // Redraw rectangle
+        this.viewrectangleChanged();
+      },
+      viewrectangleChanged: function () {
+        // Canvas to grey out outside view
+        var context = this.$.outcanvas.getContext('2d');
+        context = unwrap(context);
+
+        var properties = {
+            width: this.width,
+            height: this.height,
+            scale: this.scale,
+            thumbscale: this.thumbscale,
+            thumbrectangle: this.thumbrectangle, 
+            viewrectangle: this.viewrectangle,
+            viewBoxBorder: this.viewBoxBorder,
+            viewBoxBorder2: this.viewBoxBorder2,
+            outsideFill: this.outsideFill,
+        };
+        var nav = TheGraph.nav.render(context, this.$.viewrect, properties);
+        this.hide = nav.hide;
+        // this.scaledviewrectangle = [x, y, w, h];
+      },
+      hideChanged: function () {
+        if (this.hide) {
+          this.style.display = "none";
+        } else {
+          this.style.display = "block";
+        }
+      },
+      thumbscaleChanged: function () {
+        this.viewrectangleChanged();
+      },
+      thumbrectangleChanged: function () {
+        // Binding this from the-graph-thumb to know the dimensions rendered
+        var w = this.thumbrectangle[2];
+        var h = this.thumbrectangle[3];
+        this.thumbscale = (w>h) ? this.width/w : this.height/h;
+      }
+    });
+
+  })();
+  </script>
+</polymer-element>

--- a/elements/the-graph-thumb.html
+++ b/elements/the-graph-thumb.html
@@ -1,0 +1,109 @@
+<!--
+* Renders a fbp-graph instance into a canvas
+* Autoscales the render to fit, and exposes the scale as thumbscale, thumbrectangle, viewrectangle
+-->
+<polymer-element name="the-graph-thumb" attributes="graph width height thumbscale thumbrectangle theme">
+  <template>
+    <canvas id="canvas" width="{{width}}" height="{{height}}" style="position:absolute;top:0;left:0;"></canvas>
+  </template>
+  <script>
+  (function () {
+    "use strict";
+
+    Polymer('the-graph-thumb', {
+      graph: null,
+      width: 200,
+      height: 150,
+      thumbscale: 1,
+      nodeSize: 60,
+      fillStyle: "hsl(184, 8%, 10%)",
+      strokeStyle: "hsl(180, 11%, 70%)",
+      lineWidth: 0.75,
+      theme: "dark",
+      edgeColors: [
+        "white",
+        "hsl(  0, 100%, 46%)",
+        "hsl( 35, 100%, 46%)",
+        "hsl( 60, 100%, 46%)",
+        "hsl(135, 100%, 46%)",
+        "hsl(160, 100%, 46%)",
+        "hsl(185, 100%, 46%)",
+        "hsl(210, 100%, 46%)",
+        "hsl(285, 100%, 46%)",
+        "hsl(310, 100%, 46%)",
+        "hsl(335, 100%, 46%)"
+      ],
+      ready: function () {
+        this.thumbrectangle = [0,0,500,500];
+        this.viewrectangle = [0,0,200,150];
+      },
+      attached: function () {
+        this.style.width = this.width + "px";
+        this.style.height = this.height + "px";
+        this.themeChanged();
+      },
+      themeChanged: function () {
+        var style = TheGraph.thumb.styleFromTheme(this.theme);
+        this.edgeColors = style.edgeColors;
+        this.fillStyle = style.fill;
+        this.strokeStyle = style.stroke;
+        // Redraw
+        this.redrawGraph();
+      },
+      redrawGraph: function () {
+        if (!this.graph) {
+          return;
+        }
+        var context = this.$.canvas.getContext("2d");
+        if (!context) {
+          // ???
+          setTimeout( this.redrawGraph.bind(this), 500);
+          return;
+        }
+        // Need the actual context, not polymer-wrapped one
+        context = unwrap(context);
+
+        var properties = {
+            width: this.width,
+            height: this.height,
+            edgeColors: this.edgeColors,
+            nodeSize: this.nodeSize,
+            strokeStyle: this.strokeStyle,
+            fillStyle: this.fillStyle,
+            lineWidth: this.lineWidth,
+        };
+        var thumb = TheGraph.thumb.render(context, this.graph, properties);
+
+        this.thumbrectangle = thumb.rectangle;
+        this.thumbscale = thumb.scale;
+      },
+      listener: null,
+      graphChanged: function (oldGraph, newGraph) {
+        if (!this.listener) {
+          this.listener = this.redrawGraph.bind(this);
+        }
+        if (oldGraph) {
+          oldGraph.removeListener('endTransaction', this.listener);
+        }
+        if (!this.graph) {
+          return;
+        }
+        this.graph.on('endTransaction', this.listener);
+        this.redrawGraph();
+      },
+      widthChanged: function () {
+        this.style.width = this.width + "px";
+        this.redrawGraph();
+      },
+      heightChanged: function () {
+        this.style.height = this.height + "px";
+        this.redrawGraph();
+      },
+      toDataURL: function () {
+        return this.$.canvas.toDataURL();
+      }
+    });
+
+  })();
+  </script>
+</polymer-element>

--- a/elements/the-graph.html
+++ b/elements/the-graph.html
@@ -1,0 +1,345 @@
+<polymer-element name="the-graph" attributes="graph menus library width height autolayout theme selectedNodes errorNodes selectedEdges animatedEdges getMenuDef pan scale maxZoom minZoom displaySelectionGroup forceSelection offsetY offsetX readonly" touch-action="none">
+
+
+  <template>
+    <link rel="stylesheet" href="../themes/the-graph-dark.css">
+    <link rel="stylesheet" href="../themes/the-graph-light.css">
+    <div id="svgcontainer"></div>
+  </template>
+
+  <script>
+  (function(){
+    "use strict";
+
+    Polymer('the-graph', {
+      graph: null,
+      library: null,
+      menus: null,
+      readonly: false,
+      width: 800,
+      height: 600,
+      scale: 1,
+      minZoom: 0.15,
+      maxZoom: 15,
+      appView: null,
+      graphView: null,
+      editable: true,
+      autolayout: false,
+      grid: 72,
+      snap: 36,
+      theme: "dark",
+      selectedNodes: [],
+      selectedNodesHash: {},
+      errorNodes: {},
+      selectedEdges: [],
+      animatedEdges: [],
+      autolayouter: null,
+      displaySelectionGroup: true,
+      forceSelection: false,
+      offsetY: null,
+      offsetX: null,
+      created: function () {
+        this.library = {};
+        // Default pan
+        this.pan = [0,0];
+        // Initializes the autolayouter
+        this.autolayouter = klayNoflo.init({
+          onSuccess: this.applyAutolayout.bind(this),
+          workerScript: "../node_modules/klayjs/klay.js"
+        });
+      },
+      ready: function () {
+        this.themeChanged();
+      },
+      themeChanged: function () {
+        this.$.svgcontainer.className = "the-graph-"+this.theme;
+      },
+      graphChanged: function (oldGraph, newGraph) {
+        if (oldGraph && oldGraph.removeListener) {
+          oldGraph.removeListener("endTransaction", this.fireChanged);
+        }
+        // Listen for graph changes
+        this.graph.on("endTransaction", this.fireChanged.bind(this));
+
+        // Listen for autolayout changes
+        if (this.autolayout) {
+          this.graph.on('addNode', this.triggerAutolayout.bind(this));
+          this.graph.on('removeNode', this.triggerAutolayout.bind(this));
+          this.graph.on('addInport', this.triggerAutolayout.bind(this));
+          this.graph.on('removeInport', this.triggerAutolayout.bind(this));
+          this.graph.on('addOutport', this.triggerAutolayout.bind(this));
+          this.graph.on('removeOutport', this.triggerAutolayout.bind(this));
+          this.graph.on('addEdge', this.triggerAutolayout.bind(this));
+          this.graph.on('removeEdge', this.triggerAutolayout.bind(this));
+        }
+
+        if (this.appView) {
+          // Remove previous instance
+          ReactDOM.unmountComponentAtNode(this.$.svgcontainer);
+        }
+
+        // Setup app
+        this.$.svgcontainer.innerHTML = "";
+        this.appView = ReactDOM.render(
+          window.TheGraph.App({
+            graph: this.graph,
+            width: this.width,
+            minZoom: this.minZoom,
+            maxZoom: this.maxZoom,
+            height: this.height,
+            library: this.library,
+            menus: this.menus,
+            editable: this.editable,
+            onEdgeSelection: this.onEdgeSelection.bind(this),
+            onNodeSelection: this.onNodeSelection.bind(this),
+            onPanScale: this.onPanScale.bind(this),
+            getMenuDef: this.getMenuDef,
+            displaySelectionGroup: this.displaySelectionGroup,
+            forceSelection: this.forceSelection,
+            offsetY: this.offsetY,
+            offsetX: this.offsetX,
+            readonly: this.readonly,
+          }),
+          this.$.svgcontainer
+        );
+        this.graphView = this.appView.refs.graph;
+      },
+      onPanScale: function (x, y, scale) {
+        this.pan[0] = x;
+        this.pan[1] = y;
+        this.scale = scale;
+      },
+      onEdgeSelection: function (itemKey, item, toggle) {
+        if (itemKey === undefined) {
+          if (this.selectedEdges.length>0) {
+            this.selectedEdges = [];
+          }
+          this.fire('edges', this.selectedEdges);
+          return;
+        }
+        if (toggle) {
+          var index = this.selectedEdges.indexOf(item);
+          var isSelected = (index !== -1);
+          var shallowClone = this.selectedEdges.slice();
+          if (isSelected) {
+            shallowClone.splice(index, 1);
+            this.selectedEdges = shallowClone;
+          } else {
+            shallowClone.push(item);
+            this.selectedEdges = shallowClone;
+          }
+        } else {
+          this.selectedEdges = [item];
+        }
+        this.fire('edges', this.selectedEdges);
+      },
+      onNodeSelection: function (itemKey, item, toggle) {
+        if (itemKey === undefined) {
+          this.selectedNodes = [];
+        } else if (toggle) {
+          var index = this.selectedNodes.indexOf(item);
+          var isSelected = (index !== -1);
+          if (isSelected) {
+            this.selectedNodes.splice(index, 1);
+          } else {
+            this.selectedNodes.push(item);
+          }
+        } else {
+          this.selectedNodes = [item];
+        }
+        this.fire('nodes', this.selectedNodes);
+      },
+      selectedNodesChanged: function () {
+        var selectedNodesHash = {};
+        for (var i=0, len = this.selectedNodes.length; i<len; i++) {
+          selectedNodesHash[this.selectedNodes[i].id] = true;
+        }
+        this.selectedNodesHash = selectedNodesHash;
+        this.fire('nodes', this.selectedNodes);
+      },
+      selectedNodesHashChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setSelectedNodes(this.selectedNodesHash);
+      },
+      errorNodesChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setErrorNodes(this.errorNodes);
+      },
+      selectedEdgesChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setSelectedEdges(this.selectedEdges);
+        this.fire('edges', this.selectedEdges);
+      },
+      animatedEdgesChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setAnimatedEdges(this.animatedEdges);
+      },
+      fireChanged: function (event) {
+        this.fire("changed", this);
+      },
+      autolayoutChanged: function () {
+        if (!this.graph) { return; }
+        // Only listen to changes that affect layout
+        if (this.autolayout) {
+          this.graph.on('addNode', this.triggerAutolayout.bind(this));
+          this.graph.on('removeNode', this.triggerAutolayout.bind(this));
+          this.graph.on('addInport', this.triggerAutolayout.bind(this));
+          this.graph.on('removeInport', this.triggerAutolayout.bind(this));
+          this.graph.on('addOutport', this.triggerAutolayout.bind(this));
+          this.graph.on('removeOutport', this.triggerAutolayout.bind(this));
+          this.graph.on('addEdge', this.triggerAutolayout.bind(this));
+          this.graph.on('removeEdge', this.triggerAutolayout.bind(this));
+        } else {
+          this.graph.removeListener('addNode', this.triggerAutolayout);
+          this.graph.removeListener('removeNode', this.triggerAutolayout);
+          this.graph.removeListener('addInport', this.triggerAutolayout);
+          this.graph.removeListener('removeInport', this.triggerAutolayout);
+          this.graph.removeListener('addOutport', this.triggerAutolayout);
+          this.graph.removeListener('removeOutport', this.triggerAutolayout);
+          this.graph.removeListener('addEdge', this.triggerAutolayout);
+          this.graph.removeListener('removeEdge', this.triggerAutolayout);
+        }
+      },
+      triggerAutolayout: function (event) {
+        var graph = this.graph;
+        var portInfo = this.graphView ? this.graphView.portInfo : null;
+        // Calls the autolayouter
+        this.autolayouter.layout({
+          "graph": graph,
+          "portInfo": portInfo,
+          "direction": "RIGHT",
+          "options": {
+            "intCoordinates": true,
+            "algorithm": "de.cau.cs.kieler.klay.layered",
+            "layoutHierarchy": true,
+            "spacing": 36,
+            "borderSpacing": 20,
+            "edgeSpacingFactor": 0.2,
+            "inLayerSpacingFactor": 2.0,
+            "nodePlace": "BRANDES_KOEPF",
+            "nodeLayering": "NETWORK_SIMPLEX",
+            "edgeRouting": "POLYLINE",
+            "crossMin": "LAYER_SWEEP",
+            "direction": "RIGHT"
+          }
+        });
+      },
+      applyAutolayout: function (keilerGraph) {
+        this.graph.startTransaction("autolayout");
+        TheGraph.autolayout.applyToGraph(this.graph, keilerGraph, { snap: this.snap });
+        this.graph.endTransaction("autolayout");
+
+        // Fit to window
+        this.triggerFit();
+
+      },
+      triggerFit: function () {
+        if (this.appView) {
+          this.appView.triggerFit();
+        }
+      },
+      widthChanged: function () {
+        if (!this.appView) { return; }
+        this.appView.setState({
+          width: this.width
+        });
+      },
+      heightChanged: function () {
+        if (!this.appView) { return; }
+        this.appView.setState({
+          height: this.height
+        });
+      },
+      updateIcon: function (nodeId, icon) {
+        if (!this.graphView) { return; }
+        this.graphView.updateIcon(nodeId, icon);
+      },
+      rerender: function (options) {
+        // This is throttled with rAF internally
+        if (!this.graphView) { return; }
+        this.graphView.markDirty(options);
+      },
+      addNode: function (id, component, metadata) {
+        if (!this.graph) { return; }
+        this.graph.addNode(id, component, metadata);
+      },
+      getPan: function () {
+        if (!this.appView) {
+          return [0, 0];
+        }
+        return [this.appView.state.x, this.appView.state.y];
+      },
+      panChanged: function () {
+        // Send pan back to React
+        if (!this.appView) { return; }
+        this.appView.setState({
+          x: this.pan[0],
+          y: this.pan[1]
+        });
+      },
+      getScale: function () {
+        if (!this.appView) {
+          return 1;
+        }
+        return this.appView.state.scale;
+      },
+      displaySelectionGroupChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setState({
+          displaySelectionGroup: this.displaySelectionGroup
+        });
+      },
+      forceSelectionChanged: function () {
+        if (!this.graphView) { return; }
+        this.graphView.setState({
+          forceSelection: this.forceSelection
+        });
+      },
+      focusNode: function (node) {
+        this.appView.focusNode(node);
+      },
+      menusChanged: function () {
+        // Only if the object itself changes,
+        // otherwise builds menu from reference every time menu shown
+        if (!this.appView) { return; }
+        this.appView.setProps({menus: this.menus});
+      },
+      readonlyChanged: function () {
+        this.appView.setProps({ readonly: this.readonly});
+      },
+      debounceLibraryRefeshTimer: null,
+      debounceLibraryRefesh: function () {
+        // Breaking the "no debounce" rule, this fixes #76 for subgraphs
+        if (this.debounceLibraryRefeshTimer) {
+          clearTimeout(this.debounceLibraryRefeshTimer);
+        }
+        this.debounceLibraryRefeshTimer = setTimeout(function () {
+          this.rerender({libraryDirty:true});
+        }.bind(this), 200);
+      },
+      registerComponent: function (definition, generated) {
+        var component = this.library[definition.name];
+        var def = definition;
+        if (component) {
+          if (generated) {
+            // Don't override real one with generated dummy
+            return;
+          }
+          def = TheGraph.library.mergeComponentDefinition(component, definition);
+        }
+        this.library[definition.name] = def;
+        // So changes are rendered
+        this.debounceLibraryRefesh();
+      },
+      getComponent: function (name) {
+        return this.library[name];
+      },
+      toJSON: function () {
+        if (!this.graph) { return {}; }
+        return this.graph.toJSON();
+      }
+    });
+
+  })();
+  </script>
+</polymer-element>


### PR DESCRIPTION
Refs #537 

Seems to work just fine. 
Only the import paths was changed wrt to the original code.

These elements will be removed from the-graph as soon as there is a way to use the functionality without Polymer. Nav and thumb are already gone in git master.

Might want to wait until https://github.com/flowhub/the-graph/pull/356 is completed. It may be that existing PolymerGestures will have issues when going to Polymer 1.0+