### PR TITLE
Selective push and repo data when editing as project

### DIFF
--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -71,6 +71,8 @@ exports.getComponent = ->
         repo = path.basename pathname, path.extname pathname
         project.repo = "#{org}/#{repo}"
         project.name = project.repo
+    if data.payload.runtime?.definition?.repositoryVersion
+      project.branch = data.payload.runtime.definition.repositoryVersion
 
     # Start with the data we already have
     graphs = data.payload.graphs.slice 0
@@ -109,6 +111,7 @@ exports.getComponent = ->
         name: project.name
         namespace: project.namespace
         repo: project.repo
+        branch: project.branch
         type: project.type
         main: project.main
 

--- a/components/RuntimeToProject.coffee
+++ b/components/RuntimeToProject.coffee
@@ -1,5 +1,7 @@
 noflo = require 'noflo'
 uuid = require 'uuid'
+url = require 'url'
+path = require 'path'
 
 isComponentInProject = (namespace, componentName) ->
   return true if componentName.indexOf('/') is -1
@@ -61,6 +63,15 @@ exports.getComponent = ->
       specs: []
     project.name = project.namespace if project.namespace
 
+    if data.payload.runtime?.definition?.repository
+      parsed = url.parse data.payload.runtime.definition.repository
+      if parsed.hostname is 'github.com' and parsed.pathname
+        pathname = parsed.pathname.slice 1
+        org = path.dirname pathname
+        repo = path.basename pathname, path.extname pathname
+        project.repo = "#{org}/#{repo}"
+        project.name = project.repo
+
     # Start with the data we already have
     graphs = data.payload.graphs.slice 0
     components = []
@@ -97,6 +108,7 @@ exports.getComponent = ->
         id: project.id
         name: project.name
         namespace: project.namespace
+        repo: project.repo
         type: project.type
         main: project.main
 

--- a/elements/noflo-project-sync.html
+++ b/elements/noflo-project-sync.html
@@ -25,7 +25,7 @@
             <td>
               <select name="{{ entry.path }}" style="font-family: FontAwesome,SourceCodePro,Helvetica,Arial,sans-serif;" on-change="{{ choose }}">
                 <option value="push">&#xf093; push</option>
-                <option value="noop">&#xf05e; ignore</option>
+                <option value="noop" selected>&#xf05e; ignore</option>
               </select>
             </td>
           </tr>

--- a/elements/noflo-project-sync.html
+++ b/elements/noflo-project-sync.html
@@ -14,7 +14,7 @@
               <select name="{{ entry.path }}" style="font-family: FontAwesome,SourceCodePro,Helvetica,Arial,sans-serif;" on-change="{{ choose }}">
                 <option value="push">&#xf093; push</option>
                 <option value="pull">&#xf019; pull</option>
-                <option value="noop">&#xf05e; ignore</option>
+                <option value="noop" selected>&#xf05e; ignore</option>
               </select>
             </td>
           </tr>


### PR DESCRIPTION
Makes the "Edit as Project" workflow slightly more comfortable by:

* Making all files to push default to _Ignore_ so users can do more selective pushes
* Populating project repo and branch info from runtime when available