### PR TITLE
Update MsgFlo component templates

### DIFF
--- a/elements/noflo-component-editor.html
+++ b/elements/noflo-component-editor.html
@@ -198,6 +198,15 @@
         if (info && info.componenttemplates && info.componenttemplates[this.component.language]) {
           template = info.componenttemplates[this.component.language];
         }
+        if (template) {
+          // Allow passing project/component data to template
+          var _ = require('underscore');
+          var templateFunc = _.template(template);
+          template = templateFunc({
+            namespace: this.project.namespace || this.project.id,
+            name: this.component.name
+          });
+        }
         return template;
       },
       themeChanged: function () {

--- a/elements/noflo-new-component.html
+++ b/elements/noflo-new-component.html
@@ -41,6 +41,10 @@
       },
       nameChanged: function () {
         var duplicates = [];
+        if (this.name) {
+          // Same regexp as used by the FBP language parser
+          this.name = this.name.replace(/[^a-zA-Z0-9]+/g, "_");
+        }
         if (this.project) {
           duplicates = this.project.components.filter(function (component) {
             if (component.name === this.name) {

--- a/runtimeinfo/msgflo.yaml
+++ b/runtimeinfo/msgflo.yaml
@@ -8,16 +8,20 @@ runtimetypes:
 componenttemplates:
   python: |
     #!/usr/bin/env python
-    import sys, os, json, logging
-    sys.path.append(os.path.abspath("."))
-    import gevent
     import msgflo
 
-    class Repeat(msgflo.Participant):
+    class <%= name %>(msgflo.Participant):
       def __init__(self, role):
         d = {
           'component': '<%= namespace %>/<%= name %>',
           'label': 'Repeat input data without change',
+          'icon': 'star-o',
+          'inports': [
+            { 'id': 'in', 'type': 'any' },
+          ],
+          'outports': [
+            { 'id': 'out', 'type': 'any' },
+          ],
         }
         msgflo.Participant.__init__(self, d, role)
 
@@ -25,22 +29,8 @@ componenttemplates:
         self.send('out', msg.data)
         self.ack(msg)
 
-
-    def main():
-      waiter = gevent.event.AsyncResult()
-      role = sys.argv[1] if len(sys.argv) > 1 else 'repeat'
-      repeater = Repeat(role)
-      engine = msgflo.run(repeater, done_cb=waiter.set)
-
-      print "Repeat running on %s" % (engine.broker_url)
-      sys.stdout.flush()
-      waiter.wait()
-      print "Shutdown"
-      sys.stdout.flush()
-
     if __name__ == '__main__':
-      logging.basicConfig()
-      main()
+      msgflo.main(<%= name %>)
   coffeescript: |
     # To work in msgflo-nodejs source tree
     try
@@ -48,7 +38,7 @@ componenttemplates:
     catch e
       msgflo = require '..'
 
-    RepeatParticipant = (client, role) ->
+    <%= name %> = (client, role) ->
 
       definition =
         component: '<%= namespace %>/<%= name %>'
@@ -66,7 +56,7 @@ componenttemplates:
         return callback 'out', null, indata
       return new msgflo.participant.Participant client, definition, process, role
 
-    module.exports = RepeatParticipant
+    module.exports = <%= name %>
   javascript: |
     try {
       var msgflo = require('msgflo-nodejs');
@@ -75,7 +65,7 @@ componenttemplates:
       var msgflo = require('..');
     }
 
-    var RepeatParticipant = function(client, role) {
+    var <%= name %> = function(client, role) {
       var definition = {
         component: '<%= namespace %>/<%= name %>',
         icon: 'file-word-o',
@@ -99,7 +89,7 @@ componenttemplates:
       return new msgflo.participant.Participant(client, definition, process, role);
     };
 
-    module.exports = RepeatParticipant;
+    module.exports = <%= name %>;
   yaml: |
     # Declare MsgFlo participant on behalf of code which does not send discovery message by itself
     component: '<%= namespace %>/<%= name %>'

--- a/runtimeinfo/msgflo.yaml
+++ b/runtimeinfo/msgflo.yaml
@@ -16,7 +16,7 @@ componenttemplates:
     class Repeat(msgflo.Participant):
       def __init__(self, role):
         d = {
-          'component': 'Repeat',
+          'component': '<%= namespace %>/<%= name %>',
           'label': 'Repeat input data without change',
         }
         msgflo.Participant.__init__(self, d, role)
@@ -51,7 +51,7 @@ componenttemplates:
     RepeatParticipant = (client, role) ->
 
       definition =
-        component: 'Repeat'
+        component: '<%= namespace %>/<%= name %>'
         icon: 'file-word-o'
         label: 'Repeats in data without changes'
         inports: [
@@ -77,7 +77,7 @@ componenttemplates:
 
     var RepeatParticipant = function(client, role) {
       var definition = {
-        component: 'Repeat',
+        component: '<%= namespace %>/<%= name %>',
         icon: 'file-word-o',
         label: 'Repeats in data without changes',
         inports: [
@@ -102,7 +102,7 @@ componenttemplates:
     module.exports = RepeatParticipant;
   yaml: |
     # Declare MsgFlo participant on behalf of code which does not send discovery message by itself
-    component: DoorLock
+    component: '<%= namespace %>/<%= name %>'
     label: Open the door
     icon: lightbulb-o
     inports:


### PR DESCRIPTION
At the moment writing new components for MsgFlo in Flowhub is a bit confusing since the python code is old, and the component definitions don't have correct names, making them not runnable.

This fixes both.

Creating a new component:

![screenshot 2017-06-21 at 20 25 05](https://user-images.githubusercontent.com/3346/27400229-c54eae02-56bf-11e7-9fe8-9f19a005533e.png)

Resulting component stub:

![screenshot 2017-06-21 at 20 25 15](https://user-images.githubusercontent.com/3346/27400242-d045bf9e-56bf-11e7-972c-9ed3e47dc10e.png)

cc/ @uwekamper @cannonerd 
