### PR TITLE
use node_modules grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,15 @@ Go to the checkout folder and run:
 
     $ npm install
 
-You also need the [Grunt](http://gruntjs.com/) build tool:
-
-    $ sudo npm install -g grunt-cli
-
 This will provide you with all the needed development dependencies. Now you can build a new version by running:
 
-    $ grunt build
+    $ npm run build
 
 You have to run this command as an administrator on Windows.
 
 If you prefer, you can also start a watcher process that will do a rebuild whenever one of the files changes:
 
-    $ grunt watch
+    $ npm run watch
 
 Serve the UI using a webserver, then open the URL it in a web browser. Example:
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
   },
   "scripts": {
     "test": "grunt test",
-    "start": "./node_modules/.bin/simple-server . 9999"
+    "start": "simple-server . 9999",
+    "build": "grunt build",
+    "watch": "grunt watch"
   },
   "keywords": [
     "noflo",


### PR DESCRIPTION
Within package scripts, `grunt` and `simple-server` refer to the node_modules version, so we don’t need to install grunt globally. 