### PR TITLE
Filter component languages by project type

### DIFF
--- a/elements/noflo-new-component.html
+++ b/elements/noflo-new-component.html
@@ -48,6 +48,12 @@
           type: String,
           value: ''
         },
+        type: {
+          type: String,
+          value: '',
+          notify: true,
+          observer: 'typeChanged'
+        },
         languages: {
           type: Array,
           value: function () {
@@ -106,8 +112,7 @@
           value: function() {
             return {};
           },
-          notify: true,
-          observer: 'projectChanged'
+          notify: true
         }
       },
       attached: function () {
@@ -117,12 +122,13 @@
       detached: function () {
         Polymer.dom(document.getElementById('container')).classList.remove('blur');
       },
-      projectChanged: function () {
-        if (!this.project.type) {
-          // No type defined for project, keep full list
+      typeChanged: function () {
+        console.log(this.type);
+        if (!this.type) {
+          // No type defined, keep full list
           return;
         }
-        var runtimeInfo = require('noflo-ui/runtimeinfo')[this.project.type];
+        var runtimeInfo = require('noflo-ui/runtimeinfo')[this.type];
         if (!runtimeInfo || !runtimeInfo.componenttemplates) {
           // We don't know what languages the runtime supports, so keep full list
           return;

--- a/elements/noflo-new-component.html
+++ b/elements/noflo-new-component.html
@@ -19,14 +19,9 @@
         <label>
           Language
           <select name="type" value="{{language::input}}">
-            <option value="coffeescript">CoffeeScript</option>
-            <option value="javascript">JavaScript</option>
-            <option value="es2015">ES2015 (Babel)</option>
-            <option value="c">C</option>
-            <option value="c++">C++</option>
-            <option value="supercollider">SuperCollider</option>
-            <option value="python">Python</option>
-            <option value="yaml">YAML</option>
+            <template is="dom-repeat" items="{{languages}}" as="lang">
+            <option value="[[lang.id]" selected$="[[_languageSelected(lang, language)]]">[[lang.label]]</option>
+            </template>
           </select>
         </label>
         <label>
@@ -51,7 +46,46 @@
         },
         language: {
           type: String,
-          value: 'coffeescript'
+          value: ''
+        },
+        languages: {
+          type: Array,
+          value: function () {
+            return [
+              {
+                id: 'c',
+                label: 'C'
+              },
+              {
+                id: 'c++',
+                label: 'C++'
+              },
+              {
+                id: 'coffeescript',
+                label: 'CoffeeScript'
+              },
+              {
+                id: 'es2015',
+                label: 'ES2015 (modern JavaScript)'
+              },
+              {
+                id: 'javascript',
+                label: 'JavaScript'
+              },
+              {
+                id: 'python',
+                label: 'Python'
+              },
+              {
+                id: 'supercollider',
+                label: 'SuperCollider'
+              },
+              {
+                id: 'yaml',
+                label: 'YAML'
+              },
+            ];
+          }
         },
         name: {
           type: String,
@@ -140,6 +174,12 @@
       listeners: { click: 'close' },
       _computeClass: function (canSend) {
         return this.tokenList({ disabled: !canSend });
+      },
+      _languageSelected(lang, selected) {
+        if (lang.id === selected) {
+          return true;
+        }
+        return false;
       },
       tokenList: function (obj) {
         var pieces = [];

--- a/elements/noflo-new-component.html
+++ b/elements/noflo-new-component.html
@@ -102,9 +102,12 @@
           notify: true
         },
         project: {
-          type: String,
-          value: '',
-          notify: true
+          type: Object,
+          value: function() {
+            return {};
+          },
+          notify: true,
+          observer: 'projectChanged'
         }
       },
       attached: function () {
@@ -113,6 +116,32 @@
       },
       detached: function () {
         Polymer.dom(document.getElementById('container')).classList.remove('blur');
+      },
+      projectChanged: function () {
+        if (!this.project.type) {
+          // No type defined for project, keep full list
+          return;
+        }
+        var runtimeInfo = require('noflo-ui/runtimeinfo')[this.project.type];
+        if (!runtimeInfo || !runtimeInfo.componenttemplates) {
+          // We don't know what languages the runtime supports, so keep full list
+          return;
+        }
+
+        // Filter list of languages to the ones supported by the runtime
+        var allLanguages = this.languages;
+        this.languages = allLanguages.filter(function (lang) {
+          if (!runtimeInfo.componenttemplates[lang.id]) {
+            return false;
+          }
+          return true;
+        });
+        if (!this.languages.length) {
+          // Default back to all
+          this.languages = allLanguages;
+        }
+        // Default to first language if runtime has no preference
+        this.language = runtimeInfo.preferredlanguage || this.languages[0].id;
       },
       nameChanged: function () {
         var duplicates = [];

--- a/elements/noflo-project-inspector.html
+++ b/elements/noflo-project-inspector.html
@@ -119,19 +119,12 @@
         req.send(payload);
       },
       updateProject: function () {
-        this.project.graphs.forEach(function (graph) {
-          if (graph.id === this.main && graph.properties.environment.runtime) {
-            type = graph.properties.environment.runtime;
-            this.set('project.mainGraph', graph);
-          }
-        }.bind(this));
-        var type = this.project.type;
         this.fire('updated', {
           id: this.project.id,
           name: this.name,
           namespace: this.namespace,
           main: this.main,
-          type: type,
+          type: this.project.type,
           repo: this.repo
         });
         this.close();

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -379,6 +379,13 @@
               this.set('project.branch', 'master');
             }
           }
+          this.project.graphs.forEach(function (graph) {
+            if (graph.properties.id === this.project.main) {
+              type = graph.properties.environment.type;
+              this.set('project.mainGraph', graph);
+              this.set('project.type', type);
+            }
+          }.bind(this));
           // Send only the data we actually want to store
           this.fire('changed', this.project);
         }.bind(this));

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -341,6 +341,11 @@
         }
         var dialog = document.createElement('noflo-new-component');
         dialog.project = this.project;
+        if (this.graph && this.graph.properties.environment) {
+          dialog.type = this.graph.properties.environment.type || this.project.type;
+        } else {
+          dialog.type = this.project.type;
+        }
         Polymer.dom(document.body).appendChild(dialog);
         dialog.addEventListener('new', function (event) {
           var component = event.detail;

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -323,6 +323,11 @@
         var dialog = document.createElement('noflo-new-graph');
         dialog.project = this.project;
         dialog.runtimes = this.runtimes;
+        if (this.graph && this.graph.properties.environment) {
+          dialog.type = this.graph.properties.environment.type || this.project.type;
+        } else {
+          dialog.type = this.project.type;
+        }
         Polymer.dom(document.body).appendChild(dialog);
         dialog.addEventListener('new', function (event) {
           var graph = event.detail;

--- a/runtimeinfo/msgflo.yaml
+++ b/runtimeinfo/msgflo.yaml
@@ -4,7 +4,7 @@ runtimetypes:
     icon: cubes
     description: 'Message queue orchestration'
     helpurl: 'https://msgflo.org/docs/usage/'
-
+preferredlanguage: python
 componenttemplates:
   python: |
     #!/usr/bin/env python

--- a/runtimeinfo/noflo.yaml
+++ b/runtimeinfo/noflo.yaml
@@ -14,7 +14,7 @@ runtimetypes:
     icon: desktop
     description: 'Build GNOME desktop applications'
     helpurl: 'https://github.com/noflo/noflo-gnome#readme'
-
+preferredlanguage: es2015
 componenttemplates:
   javascript: |
     var noflo = require('noflo');


### PR DESCRIPTION
Half-way to solving #206. It would still be nice to have runtime telling what languages they support, as there may be optional ones, like CoffeeScript only working with NoFlo runtimes if the CoffeeScript compiler is installed.

Some examples...

NoFlo:
![screenshot 2017-11-14 at 16 20 01](https://user-images.githubusercontent.com/3346/32787965-406f3d94-c958-11e7-8020-4bb2622837ad.png)
MsgFlo:
![screenshot 2017-11-14 at 16 19 48](https://user-images.githubusercontent.com/3346/32787966-40a8a85e-c958-11e7-8298-0884091f14e8.png)
ImgFlo:
![screenshot 2017-11-14 at 16 20 43](https://user-images.githubusercontent.com/3346/32787963-4021e8dc-c958-11e7-9790-c424a8c8192d.png)
Unknown type (all languages listed):
![screenshot 2017-11-14 at 16 20 25](https://user-images.githubusercontent.com/3346/32787964-4052fb2a-c958-11e7-857e-a4b7473d33bd.png)