### PR TITLE
Fix CodeMirror line numbering overlapping with contents

### DIFF
--- a/elements/noflo-component-editor.html
+++ b/elements/noflo-component-editor.html
@@ -154,7 +154,6 @@
       getMirrorOptions: function (component, value) {
         var options = {
           lineNumbers: true,
-          lineWrapping: true,
           value: value || '',
           mode: this.getMirrorMode(component.language),
           theme: this.getMirrorTheme(),
@@ -241,9 +240,11 @@
         var height = this.height - 102;
         if (this.codeEditor) {
           this.codeEditor.setSize(width, height);
+          this.codeEditor.refresh();
         }
         if (this.testsEditor) {
           this.testsEditor.setSize(width, height);
+          this.testsEditor.refresh();
         }
       }
     });

--- a/elements/noflo-component-editor.html
+++ b/elements/noflo-component-editor.html
@@ -154,6 +154,7 @@
       getMirrorOptions: function (component, value) {
         var options = {
           lineNumbers: true,
+          lineWrapping: true,
           value: value || '',
           mode: this.getMirrorMode(component.language),
           theme: this.getMirrorTheme(),
@@ -236,7 +237,7 @@
         if (!this.width || !this.height) {
           return;
         }
-        var width = (this.width - 80) / 2;
+        var width = (this.width - 90) / 2;
         var height = this.height - 102;
         if (this.codeEditor) {
           this.codeEditor.setSize(width, height);

--- a/elements/noflo-graph-inspector.html
+++ b/elements/noflo-graph-inspector.html
@@ -9,6 +9,8 @@
       .CodeMirror {
         height: 100%;
         cursor: text;
+        margin-left: -2px;
+        margin-right: -2px;
       }
       .CodeMirror-scroll {
         height: 100%;
@@ -286,6 +288,7 @@
         }
         this.htmlEditor = CodeMirror(this.$.html_editor, {
           lineNumbers: false,
+          lineWrapping: true,
           value: this.graph.properties.environment.content || '',
           language: 'htmlmixed',
           theme: 'mdn-like',
@@ -297,6 +300,7 @@
         }
         this.testsEditor = CodeMirror(this.$.tests_editor, {
           lineNumbers: false,
+          lineWrapping: true,
           value: this.spec.code || '',
           mode: this.getMirrorMode(this.spec.language),
           theme: 'mdn-like'

--- a/elements/noflo-graph-inspector.html
+++ b/elements/noflo-graph-inspector.html
@@ -9,8 +9,6 @@
       .CodeMirror {
         height: 100%;
         cursor: text;
-        margin-left: -2px;
-        margin-right: -2px;
       }
       .CodeMirror-scroll {
         height: 100%;
@@ -271,13 +269,15 @@
       viewChanged: function () {
         if (this.view === 'html' && this.htmlEditor) {
           setTimeout(function () {
-            this.htmlEditor.setSize(576, 288);
+            this.htmlEditor.setSize(576 - 4, 288);
+            this.htmlEditor.refresh();
             this.htmlEditor.focus();
           }.bind(this), 1);
         }
         if (this.view === 'tests' && this.testsEditor) {
           setTimeout(function () {
-            this.testsEditor.setSize(576, 288);
+            this.testsEditor.setSize(576 - 4, 288);
+            this.testsEditor.refresh();
             this.testsEditor.focus();
           }.bind(this), 1);
         }
@@ -287,7 +287,7 @@
           return;
         }
         this.htmlEditor = CodeMirror(this.$.html_editor, {
-          lineNumbers: false,
+          lineNumbers: true,
           lineWrapping: true,
           value: this.graph.properties.environment.content || '',
           language: 'htmlmixed',
@@ -299,7 +299,7 @@
           return;
         }
         this.testsEditor = CodeMirror(this.$.tests_editor, {
-          lineNumbers: false,
+          lineNumbers: true,
           lineWrapping: true,
           value: this.spec.code || '',
           mode: this.getMirrorMode(this.spec.language),

--- a/elements/noflo-graph-inspector.html
+++ b/elements/noflo-graph-inspector.html
@@ -288,7 +288,6 @@
         }
         this.htmlEditor = CodeMirror(this.$.html_editor, {
           lineNumbers: true,
-          lineWrapping: true,
           value: this.graph.properties.environment.content || '',
           language: 'htmlmixed',
           theme: 'mdn-like',
@@ -300,7 +299,6 @@
         }
         this.testsEditor = CodeMirror(this.$.tests_editor, {
           lineNumbers: true,
-          lineWrapping: true,
           value: this.spec.code || '',
           mode: this.getMirrorMode(this.spec.language),
           theme: 'mdn-like'


### PR DESCRIPTION
In graph inspector (before/after)

![screenshot 2017-11-16 at 20 46 13](https://user-images.githubusercontent.com/3346/32913024-514e6724-cb11-11e7-8194-96119093ee5f.png)
![screenshot 2017-11-16 at 20 54 07](https://user-images.githubusercontent.com/3346/32913031-59bcfefc-cb11-11e7-8062-390dc5c15645.png)

In component editor (before/after)

![screenshot 2017-11-16 at 20 55 31](https://user-images.githubusercontent.com/3346/32913041-6915bf24-cb11-11e7-8511-778c187353ca.png)
![screenshot 2017-11-16 at 20 57 32](https://user-images.githubusercontent.com/3346/32913048-6e26f6ae-cb11-11e7-8555-a45f669c1b96.png)

Related to:

* https://github.com/codemirror/CodeMirror/issues/3098
* https://github.com/codemirror/CodeMirror/issues/2469