### PR TITLE
Inception mode: postMessage runtime

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -72,6 +72,7 @@ window.addEventListener('WebComponentsReady', function() {
         'component:getsource',
         'component:setsource'
       ];
+      runtimeOptions.label = '$NOFLO_APP_TITLE';
       runtimeOptions.id = '2b487ea3-287b-43f7-b7eb-806f02b402f9'
       runtimeOptions.namespace = 'ui';
       runtimeOptions.repository = 'git+https://github.com/noflo/noflo-ui.git'
@@ -88,7 +89,10 @@ window.addEventListener('WebComponentsReady', function() {
   };
 
   window.nofloStarted = false;
-  var load = (false) ? loadGraphsDebuggable : loadGraphs;
+  load = loadGraphs;
+  if (String(localStorage.getItem('flowhub-debug')) === 'true') {
+    load = loadGraphsDebuggable;
+  }
   load(function(err) {
     if (err) {
       throw err;

--- a/app/main.js
+++ b/app/main.js
@@ -72,19 +72,18 @@ window.addEventListener('WebComponentsReady', function() {
         'component:getsource',
         'component:setsource'
       ];
-      var rt = runtime(null, runtimeOptions, true);
-      rt.start();
-      var ide = 'http://app.flowhub.io';
-      var debugUrl = ide+'#runtime/endpoint?'+encodeURIComponent('protocol=webrtc&address='+rt.signaller+'#'+rt.id+'&secret='+secret);
-      var debugLink = document.getElementById('flowhub_debug_url');
-      if (debugLink) {
-        debugLink.href = debugUrl;
-      } else {
-        console.log(debugUrl);
-      }
-      rt.network.on('addnetwork', function () {
-        return callback();
-      });
+      runtimeOptions.id = '2b487ea3-287b-43f7-b7eb-806f02b402f9'
+      runtimeOptions.namespace = 'ui';
+      runtimeOptions.repository = 'git+https://github.com/noflo/noflo-ui.git'
+      var debugButton = document.createElement('button');
+      debugButton.id = 'flowhub_debug_url';
+      debugButton.innerText = 'Debug in Flowhub';
+      var ide = 'https://app.flowhub.io';
+      var debugUrl = ide+'#runtime/endpoint?'+encodeURIComponent('protocol=opener&address='+window.location.href + '&id=' + runtimeOptions.id);
+      debugButton.setAttribute('href', debugUrl);
+      document.body.appendChild(debugButton);
+      runtime.opener(runtimeOptions, debugButton);
+      return callback();
     });
   };
 

--- a/components/CreateContext.coffee
+++ b/components/CreateContext.coffee
@@ -11,6 +11,7 @@ buildContext = ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'file-o'
   c.inPorts.add 'start',
     datatype: 'bang'
   c.outPorts.add 'out',

--- a/components/CreateEmptyContext.coffee
+++ b/components/CreateEmptyContext.coffee
@@ -6,6 +6,7 @@ buildContext = ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'file-o'
   c.inPorts.add 'start',
     datatype: 'bang'
   c.outPorts.add 'out',

--- a/components/CreateLoadingContext.coffee
+++ b/components/CreateLoadingContext.coffee
@@ -6,6 +6,7 @@ buildContext = ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'spinner'
   c.inPorts.add 'start',
     datatype: 'bang'
   c.outPorts.add 'out',

--- a/components/DispatchAction.coffee
+++ b/components/DispatchAction.coffee
@@ -15,6 +15,7 @@ findHandler = (actionParts, routes) ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'code-fork'
   c.inPorts.add 'routes',
     datatype: 'string'
     required: true

--- a/components/ErrorToContext.coffee
+++ b/components/ErrorToContext.coffee
@@ -11,6 +11,7 @@ buildContext = ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'exclamation-triangle'
   c.inPorts.add 'error',
     datatype: 'object'
   c.outPorts.add 'out',

--- a/components/LoadUserData.coffee
+++ b/components/LoadUserData.coffee
@@ -35,6 +35,7 @@ exports.getComponent = ->
 
     keys = [
       'flowhub-avatar'
+      'flowhub-debug'
       'flowhub-plan'
       'flowhub-theme'
       'flowhub-token'

--- a/components/LoggingMiddleware.coffee
+++ b/components/LoggingMiddleware.coffee
@@ -9,6 +9,7 @@ sendEvent = (label, action = 'click', category = 'menu') ->
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'file-text'
   c.inPorts.add 'in',
     datatype: 'all'
   c.outPorts.add 'pass',

--- a/components/SetToContext.coffee
+++ b/components/SetToContext.coffee
@@ -2,6 +2,7 @@ noflo = require 'noflo'
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'indent'
   c.inPorts.add 'context',
     datatype: 'object'
   c.inPorts.add 'key',

--- a/components/Store.coffee
+++ b/components/Store.coffee
@@ -3,6 +3,7 @@ debug = require('debug') 'noflo-ui:store'
 
 exports.getComponent = ->
   c = new noflo.Component
+  c.icon = 'rocket'
   c.inPorts.add 'action',
     datatype: 'all'
   c.inPorts.add 'state',

--- a/components/StoreUserPreferences.coffee
+++ b/components/StoreUserPreferences.coffee
@@ -2,6 +2,7 @@ noflo = require 'noflo'
 
 validPreferences = [
   'flowhub-theme'
+  'flowhub-debug'
 ]
 
 exports.getComponent = ->

--- a/css/noflo-ui.css
+++ b/css/noflo-ui.css
@@ -256,3 +256,17 @@ div.error {
   background-color: hsla(190, 100%, 20%, 0.2);
   color: hsl(190, 100%, 65%);
 }
+
+#flowhub_debug_url {
+  position: fixed;
+  bottom: 0px;
+  right: 0px;
+  font-size; 18px;
+  padding: 9px;
+  z-index: 10;
+  background-color: hsla(190, 100%, 20%, 0.2);
+  color: var(--noflo-ui-text);
+  border-left: 1px solid var(--noflo-ui-background);
+  border-top: 1px solid var(--noflo-ui-background);
+  cursor: pointer;
+}

--- a/elements/noflo-account-settings.html
+++ b/elements/noflo-account-settings.html
@@ -57,6 +57,13 @@
             <option value="light" selected$="[[_isSelectedTheme('light', theme)]]">Tube</option>
           </select>
         </label>
+        <label>
+          Debug $NOFLO_APP_TITLE in Flowhub (requires reload)
+          <select name="type" value="{{debug::input}}">
+            <option value="false" selected$="[[_isSelectedDebug('false', debug)]]">Disabled</option>
+            <option value="true" selected$="[[_isSelectedDebug('true', debug)]]">Enabled</option>
+          </select>
+        </label>
         <div class="toolbar">
           <button on-click="send">Save</button>
           <a on-click="close">Cancel</a>
@@ -70,6 +77,10 @@
       properties: {
         theme: {
           type: String,
+        },
+        debug: {
+          type: String,
+          value: 'false'
         },
         user: {
           type: Object,
@@ -91,7 +102,8 @@
         event.preventDefault();
         event.stopPropagation();
         this.fire('updated', {
-          'flowhub-theme': this.theme
+          'flowhub-theme': this.theme,
+          'flowhub-debug': this.debug
         });
         this.close();
       },
@@ -108,9 +120,13 @@
       listeners: { click: 'close' },
       userChanged: function () {
         this.theme = this.user['flowhub-theme'] || 'dark';
+        this.debug = this.user['flowhub-debug'] || 'false';
       },
       _isSelectedTheme: function (theme, current) {
         return theme === current;
+      },
+      _isSelectedDebug: function (value, current) {
+        return value === current;
       }
     });
   </script>

--- a/graphs/ContextStorage.fbp
+++ b/graphs/ContextStorage.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon search
+
 INPORT=Dispatch.IN:IN
 OUTPORT=MergeContext.OUT:CONTEXT
 

--- a/graphs/Delete.fbp
+++ b/graphs/Delete.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon trash
+
 INPORT=Write.DB:DB
 INPORT=Store.IN:STORE
 INPORT=EnsureId.IN:ITEM

--- a/graphs/DeleteData.fbp
+++ b/graphs/DeleteData.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon trash-o
+
 INPORT=Dispatch.IN:IN
 OUTPORT=DeleteProject.KEY:PROJECT
 OUTPORT=DeleteGraph.KEY:GRAPH

--- a/graphs/GithubMiddleware.fbp
+++ b/graphs/GithubMiddleware.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon github
+
 INPORT=Dispatch.IN:IN
 OUTPORT=Dispatch.PASS:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/GithubReducer.fbp
+++ b/graphs/GithubReducer.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon github
+
 INPORT=Dispatch.IN:IN
 OUTPORT=MergeContext.OUT:CONTEXT
 

--- a/graphs/GithubSynchronization.fbp
+++ b/graphs/GithubSynchronization.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon github-alt
+
 INPORT=Token.IN:TOKEN
 INPORT=RepoToPrepare.IN:PREPARE
 INPORT=DoSync.IN:SYNC

--- a/graphs/Load.fbp
+++ b/graphs/Load.fbp
@@ -1,3 +1,4 @@
+# @runtime noflo-browser
 INPORT=Read.DB:DB
 INPORT=Store.IN:STORE
 OUTPORT=Query.ITEM:ITEM

--- a/graphs/LoadData.fbp
+++ b/graphs/LoadData.fbp
@@ -1,3 +1,4 @@
+# @runtime noflo-browser
 INPORT=Dispatch.IN:IN
 OUTPORT=LoadProjects.ITEM:PROJECT
 OUTPORT=ConvertGraph.OUT:GRAPH

--- a/graphs/PrepareStorage.fbp
+++ b/graphs/PrepareStorage.fbp
@@ -1,3 +1,4 @@
+# @runtime noflo-browser
 INPORT=Open.NAME:NAME
 OUTPORT=Errors.OUT:ERROR
 OUTPORT=Open.DB:DB

--- a/graphs/RegistryMiddleware.fbp
+++ b/graphs/RegistryMiddleware.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon address-card-o
 INPORT=Dispatch.IN:IN
 OUTPORT=Passed.OUT:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/RegistryReducer.fbp
+++ b/graphs/RegistryReducer.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon address-card-o
 INPORT=Dispatch.IN:IN
 OUTPORT=MergeContext.OUT:CONTEXT
 

--- a/graphs/RuntimeMiddleware.fbp
+++ b/graphs/RuntimeMiddleware.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon cogs
 INPORT=Dispatch.IN:IN
 OUTPORT=Passed.OUT:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/RuntimeStorage.fbp
+++ b/graphs/RuntimeStorage.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon cogs
 INPORT=Dispatch.IN:IN
 INPORT=FindRuntimes.CONTEXT:CONTEXT
 OUTPORT=MergeContext.OUT:CONTEXT

--- a/graphs/StorageMiddleware.fbp
+++ b/graphs/StorageMiddleware.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon database
 INPORT=Dispatch.IN:IN
 OUTPORT=Passed.OUT:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/UrlMiddleware.fbp
+++ b/graphs/UrlMiddleware.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon slack
 INPORT=Dispatch.IN:IN
 OUTPORT=Passed.OUT:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/UserMiddleware.fbp
+++ b/graphs/UserMiddleware.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon user-circle
 INPORT=Dispatch.IN:IN
 OUTPORT=Dispatch.PASS:PASS
 OUTPORT=NewActions.OUT:NEW

--- a/graphs/UserReducer.fbp
+++ b/graphs/UserReducer.fbp
@@ -1,3 +1,5 @@
+# @runtime noflo-browser
+# @icon user-circle
 INPORT=Dispatch.IN:IN
 OUTPORT=MergeContext.OUT:CONTEXT
 

--- a/graphs/main.fbp
+++ b/graphs/main.fbp
@@ -1,3 +1,6 @@
+# @runtime noflo-browser
+# @icon code
+
 # Event dispatching
 AppView(polymer/noflo-ui) EVENT -> ACTION StoreDispatch(ui/Store)
 # Application state updates


### PR DESCRIPTION
This makes it possible to debug noflo-ui in noflo-ui. We had this feature in the past with the WebRTC runtime, but that never worked that well. Now we're using the `opener` runtime.

Enable debugging in user settings (and reload screen):

![screenshot 2017-11-20 at 21 56 30](https://user-images.githubusercontent.com/3346/33041303-2c989500-ce3e-11e7-8241-07cc29cc0ff0.png)

A debug in Flowhub button appears in bottom right corner:

![screenshot 2017-11-20 at 21 46 46](https://user-images.githubusercontent.com/3346/33041325-424026b6-ce3e-11e7-94a9-7f6582b1af54.png)

Clicking it shows you the app in Flowhub live mode:

![screenshot 2017-11-20 at 21 47 47](https://user-images.githubusercontent.com/3346/33041353-57521dac-ce3e-11e7-939c-8334656087a0.png)


