### PR TITLE
Dedupe entities in live mode

### DIFF
--- a/components/MapStateToProps.js
+++ b/components/MapStateToProps.js
@@ -1,4 +1,5 @@
 const noflo = require('noflo');
+const { graphRuntimeIdentifier } = require('../src/runtime');
 
 // Build up display model of runtime from runtime definition and status
 const populateRuntime = (s) => {
@@ -76,8 +77,10 @@ exports.getComponent = () => {
           }
           const packets = updated.runtimePackets[state.runtime.id].toarray();
           packets.reverse();
-          props.packets = packets.filter(p => p.graph === (state.graphs[0].name
-            || state.graphs[0].properties.id));
+          const namespace = state.project ? state.project.namespace : null;
+          props.packets = packets.filter(
+            p => p.graph === graphRuntimeIdentifier(state.graphs[0], namespace),
+          );
           return;
         }
         case 'runtimeEvents': {

--- a/components/OpenLiveMode.js
+++ b/components/OpenLiveMode.js
@@ -128,14 +128,13 @@ exports.getComponent = () => {
 
         return getSource(client, def.graph);
       })
-      .then(source => loadGraph({
-        ...source,
-        name: client.definition.graph, // Ensure graph gets the name runtime supplied
-      }))
+      .then(source => loadGraph(source))
       .then((graphInstance) => {
         graphInstance.setProperties({
           id: `${state.project.id}/${(graphInstance.properties != null ? graphInstance.properties.id : undefined) || graphInstance.name}`,
           project: state.project.id,
+          // Ensure graph communications use the name runtime supplied
+          runtimeName: client.definition.graph,
         });
         addToList(state.project.graphs, graphInstance);
         state.project.main = graphInstance.properties.id;

--- a/components/OpenProjectMode.js
+++ b/components/OpenProjectMode.js
@@ -4,14 +4,18 @@ const {
   getComponentType,
   getRemoteNodes,
   ensureIframe,
+  graphRuntimeIdentifier,
 } = require('../src/runtime');
 
-const sendGraphs = (client, graphs) => {
+const sendGraphs = (client, graphs, namespace = null) => {
   const compatible = graphs.filter(g => getGraphType(g) === client.definition.type);
-  return Promise.all(compatible.map(g => client.protocol.graph.send(g, g.properties.main)));
+  return Promise.all(compatible.map(g => client.protocol.graph.send({
+    ...g,
+    name: graphRuntimeIdentifier(g, namespace),
+  }, g.properties.main)));
 };
 
-const sendComponents = (client, components, namespace) => {
+const sendComponents = (client, components, namespace = null) => {
   const compatible = components.filter(c => [
     null,
     client.definition.type,
@@ -54,7 +58,7 @@ exports.getComponent = () => {
       .then(() => ensureIframe(client, route.project))
       .then(() => client.connect())
       .then(() => sendComponents(client, route.project.components, route.project.namespace))
-      .then(() => sendGraphs(client, route.project.graphs))
+      .then(() => sendGraphs(client, route.project.graphs, route.project.namespace))
       .then(() => {
         if (!(route.graphs != null ? route.graphs.length : undefined)) {
           return Promise.resolve();

--- a/components/OpenProjectMode.js
+++ b/components/OpenProjectMode.js
@@ -12,6 +12,10 @@ const sendGraphs = (client, graphs, namespace = null) => {
   return Promise.all(compatible.map(g => client.protocol.graph.send({
     ...g,
     name: graphRuntimeIdentifier(g, namespace),
+    properties: {
+      ...g.properties,
+      library: namespace,
+    },
   }, g.properties.main)));
 };
 

--- a/components/SendEdges.js
+++ b/components/SendEdges.js
@@ -1,4 +1,5 @@
 const noflo = require('noflo');
+const { graphRuntimeIdentifier } = require('../src/runtime');
 
 exports.getComponent = () => {
   const c = new noflo.Component();
@@ -6,6 +7,8 @@ exports.getComponent = () => {
     { datatype: 'object' });
   c.inPorts.add('graphs',
     { datatype: 'array' });
+  c.inPorts.add('project',
+    { datatype: 'object' });
   c.inPorts.add('edges',
     { datatype: 'array' });
   c.outPorts.add('out',
@@ -13,16 +16,17 @@ exports.getComponent = () => {
   c.outPorts.add('error',
     { datatype: 'object' });
   return c.process((input, output) => {
-    if (!input.hasData('client', 'graphs', 'edges')) { return; }
-    const [client, graphs, edges] = input.getData('client', 'graphs', 'edges');
+    if (!input.hasData('client', 'graphs', 'project', 'edges')) { return; }
+    const [client, graphs, project, edges] = input.getData('client', 'graphs', 'project', 'edges');
     output.send({ out: edges });
     if (!graphs.length) {
       output.done(new Error('No graph specified'));
       return;
     }
     const currentGraph = graphs[graphs.length - 1];
+    const namespace = project ? project.namespace : null;
     client.protocol.network.edges({
-      graph: currentGraph.name || currentGraph.properties.id,
+      graph: graphRuntimeIdentifier(currentGraph, namespace),
       edges: edges.map((e) => {
         const edge = {
           src: e.from,

--- a/components/SendNewGraph.js
+++ b/components/SendNewGraph.js
@@ -29,6 +29,10 @@ exports.getComponent = () => {
       .then(() => client.protocol.graph.send({
         ...graph,
         name: graphRuntimeIdentifier(graph, namespace),
+        properties: {
+          ...graph.properties,
+          library: namespace,
+        },
       }, graph.properties.main))
       .then((() => output.sendDone({
         out: data,

--- a/components/SendNewGraph.js
+++ b/components/SendNewGraph.js
@@ -1,5 +1,5 @@
 const noflo = require('noflo');
-const { getGraphType } = require('../src/runtime');
+const { getGraphType, graphRuntimeIdentifier } = require('../src/runtime');
 
 exports.getComponent = () => {
   const c = new noflo.Component();
@@ -15,7 +15,7 @@ exports.getComponent = () => {
     if (!input.hasData('in', 'client')) { return; }
     const [data, client] = input.getData('in', 'client');
 
-    const { graph } = data;
+    const { graph, project } = data;
     const graphType = getGraphType(graph);
     if (graphType && (graphType !== client.definition.type)) {
       // Ignore components for different runtime type
@@ -23,8 +23,13 @@ exports.getComponent = () => {
       return;
     }
 
+    const namespace = project ? project.namespace : null;
+
     client.connect()
-      .then(() => client.protocol.graph.send(graph, graph.properties.main))
+      .then(() => client.protocol.graph.send({
+        ...graph,
+        name: graphRuntimeIdentifier(graph, namespace),
+      }, graph.properties.main))
       .then((() => output.sendDone({
         out: data,
       })), err => output.done(err));

--- a/components/StartNetwork.js
+++ b/components/StartNetwork.js
@@ -1,4 +1,5 @@
 const noflo = require('noflo');
+const { graphRuntimeIdentifier } = require('../src/runtime');
 
 exports.getComponent = () => {
   const c = new noflo.Component();
@@ -14,10 +15,10 @@ exports.getComponent = () => {
     if (!input.hasData('in', 'client')) { return; }
     const [data, client] = input.getData('in', 'client');
 
-    const graphId = data.graph.name || data.graph.properties.id;
+    const namespace = data.project ? data.project.namespace : null;
     client.connect()
       .then(() => client.protocol.network.start({
-        graph: graphId,
+        graph: graphRuntimeIdentifier(data.graph, namespace),
       }))
       .then(status => output.send({
         out: {

--- a/components/StopNetwork.js
+++ b/components/StopNetwork.js
@@ -1,4 +1,5 @@
 const noflo = require('noflo');
+const { graphRuntimeIdentifier } = require('../src/runtime');
 
 exports.getComponent = () => {
   const c = new noflo.Component();
@@ -14,10 +15,10 @@ exports.getComponent = () => {
     if (!input.hasData('in', 'client')) { return; }
     const [data, client] = input.getData('in', 'client');
 
-    const graphId = data.graph.name || data.graph.properties.id;
+    const namespace = data.project ? data.project.namespace : null;
     client.connect()
       .then(() => client.protocol.network.stop({
-        graph: graphId,
+        graph: graphRuntimeIdentifier(data.graph, namespace),
       }))
       .then(status => output.send({
         out: {

--- a/elements/noflo-component-inspector.html
+++ b/elements/noflo-component-inspector.html
@@ -18,12 +18,12 @@
       }
     </style>
     <div class="modal-container" on-click="bgClick">
-      <h1><span>{{component.name}}</span></h1>
+      <h1><span>{{getName(component)}}</span></h1>
       <template is="dom-if" if="{{inGraph.length}}">
       <p>Used as component in
       <template is="dom-repeat" items="{{inGraph}}" as="parent">
         <a href$="{{_computeHref(parent, project)}}">
-          <span>{{parent.name}}</span>
+          <span>{{getName(parent)}}</span>
         </a>
       </template>
       </p>
@@ -65,9 +65,10 @@
         Polymer.dom(this).classList.add('modal-content');
         this.inGraph = [];
         if (this.project) {
+          var collections = require('noflo-ui/collections');
           this.project.graphs.forEach(function (graph) {
             graph.nodes.forEach(function (node) {
-              if (node.component === this.component.name || node.component === this.project.namespace + '/' + this.component.name) {
+              if (node.component === collections.unnamespace(this.component.name) || node.component === collections.namespace(this.component.name, this.project.namespace)) {
                 this.push('inGraph', graph);
               }
             }.bind(this));
@@ -102,7 +103,11 @@
         var hash = urls.getGraphHash(parent.properties.id, project);
         return urls.hashToString(hash);
       },
-      listeners: { click: 'close' }
+      listeners: { click: 'close' },
+      getName: function (entity) {
+        var collections = require('noflo-ui/collections');
+        return collections.unnamespace(collections.getName(entity));
+      }
     });
   </script>
 </dom-module>

--- a/elements/noflo-graph-inspector.html
+++ b/elements/noflo-graph-inspector.html
@@ -85,7 +85,7 @@
       }
     </style>
     <div class="modal-container" on-click="bgClick">
-      <input type="text" on-keydown="checkUpdateName" on-blur="updateName" class="editable-title" value="{{graph.name}}" />
+      <input type="text" on-keydown="checkUpdateName" on-blur="updateName" class="editable-title" value="{{getName(graph)}}" />
       <template is="dom-if" if="{{downloadUrl}}">
         <a id="download" download="{{_computeDownload(graph)}}" href$="{{downloadUrl}}">
           <noflo-icon icon="download"></noflo-icon>
@@ -99,7 +99,7 @@
       <p>Used as subgraph in
       <template is="dom-repeat" items="{{inGraph}}" as="parent">
         <a href$="{{_computeHref(parent, project)}}">
-          <span>{{parent.name}}</span>
+          <span>{{getName(parent)}}</span>
         </a>
       </template>
       </p>
@@ -226,26 +226,28 @@
         this.view = 'properties';
         this.inGraph = [];
         this.isMain = false;
+
+        var collections = require('noflo-ui/collections');
         if (this.project) {
           if (this.graph.properties.main) {
             this.isMain = true;
           } else {
             this.project.graphs.forEach(function (graph) {
               graph.nodes.forEach(function (node) {
-                if (node.component === this.graph.name || node.component === this.project.namespace + '/' + this.graph.name) {
+                if (node.component === collections.unnamespace(this.graph.name) || node.component === collections.namespace(this.graph.name, this.project.namespace)) {
                   this.push('inGraph', graph);
                 }
               }.bind(this));
             }.bind(this));
           }
           this.project.specs.forEach(function (spec) {
-            if (spec.name === this.graph.name) {
+            if (collections.unnamespace(spec.name) === collections.unnamespace(this.graph.name)) {
               this.spec = spec;
             }
           }.bind(this));
           if (!this.spec) {
             this.spec = {
-              name: this.graph.name,
+              name: collections.unnamespace(this.graph.name),
               changed: false,
               code: '',
               language: 'yaml',
@@ -407,7 +409,7 @@
         return this.tokenList({ hidden: view != 'tests' });
       },
       _computeDownload: function (graph) {
-        return graph.name + '.json';
+        return require('noflo-ui/collections').unnamespace(graph.name) + '.json';
       },
       _computeHref: function (parent, project) {
         var urls = require('noflo-ui/urls');
@@ -428,6 +430,10 @@
           }
         }
         return pieces.join(' ');
+      },
+      getName: function (entity) {
+        var collections = require('noflo-ui/collections');
+        return collections.unnamespace(collections.getName(entity));
       }
     });
   </script>

--- a/elements/noflo-project.html
+++ b/elements/noflo-project.html
@@ -241,7 +241,7 @@
           <template is="dom-repeat" items="{{project.graphs}}" as="graph">
           <li on-click="openGraph" data-id$="{{graph.properties.id}}">
             <the-graph-thumb graph="{{graph}}" width="200" height="120"></the-graph-thumb>
-            <h2>{{graph.name}}</h2>
+            <h2>{{getName(graph)}}</h2>
           </li>
           </template>
         </ul>
@@ -255,7 +255,7 @@
           </li>
           <template is="dom-repeat" items="{{project.components}}" as="component">
           <li on-click="openComponent" data-id$="{{component.name}}">
-            <h2>{{component.name}}</h2>
+            <h2>{{getName(component)}}</h2>
             <template is="dom-if" if="{{_computeIf(component)}}">
             <noflo-icon icon="coffee"></noflo-icon>
             </template>
@@ -485,6 +485,10 @@
           return this.runtime.definition.capabilities.indexOf('component:setsource') !== -1;
         }
         return true
+      },
+      getName: function (entity) {
+        var collections = require('noflo-ui/collections');
+        return collections.unnamespace(collections.getName(entity));
       }
     });
   </script>

--- a/elements/noflo-search.html
+++ b/elements/noflo-search.html
@@ -168,10 +168,10 @@
         </button>
         </template>
         <template is="dom-if" if="{{_isGraph(component, graph)}}">
-        <span>{{graph.name}}</span>
+        <span>{{getName(graph)}}</span>
         </template>
         <template is="dom-if" if="{{_isComponent(component)}}">
-        <span>{{component.name}}</span>
+        <span>{{getName(component)}}</span>
         </template>
       </h1>
       <template is="dom-if" if="{{_canInspectGraph(component, graph, readonly)}}">
@@ -575,6 +575,10 @@
       },
       _isReadOnly: function (component, graph, readonly) {
         return readonly || component && component.readonly || graph && graph.properties.readonly;
+      },
+      getName: function (entity) {
+        var collections = require('noflo-ui/collections');
+        return collections.unnamespace(collections.getName(entity));
       }
     });
   </script>

--- a/elements/noflo-ui.html
+++ b/elements/noflo-ui.html
@@ -234,6 +234,7 @@
           this.emitEvent('runtime:sendGraph', {
             runtime: this.ctx.runtime.definition.id,
             graph: event.detail,
+            project: this.ctx.project,
           });
         }.bind(this));
         this.$.main.addEventListener('newruntime', function (event) {
@@ -253,6 +254,7 @@
           this.emitEvent('runtime:sendGraph', {
             runtime: this.ctx.runtime.definition.id,
             graph: event.detail,
+            project: this.ctx.project,
           });
         }.bind(this));
         this.$.context.addEventListener('clear:runtimeevents', function (event) {
@@ -285,10 +287,18 @@
           this.emitEvent('storage:save:runtime', event.detail);
         }.bind(this));
         this.$.runtime.addEventListener('start', function (event) {
-          this.emitEvent('runtime:start', event.detail);
+          this.emitEvent('runtime:start', {
+            runtime: event.detail.runtime,
+            graph: event.detail.graph,
+            project: this.ctx.project,
+          });
         }.bind(this));
         this.$.runtime.addEventListener('stop', function (event) {
-          this.emitEvent('runtime:stop', event.detail);
+          this.emitEvent('runtime:stop', {
+            runtime: event.detail.runtime,
+            graph: event.detail.graph,
+            project: this.ctx.project,
+          });
         }.bind(this));
         this.$.runtime.addEventListener('reconnect', function (event) {
           this.emitEvent('runtime:reconnect', event.detail);
@@ -322,6 +332,7 @@
           this.emitEvent('runtime:sendGraph', {
             runtime: this.ctx.runtime.definition.id,
             graph: event.detail,
+            project: this.ctx.project,
           });
         }.bind(this));
         this.$.project.addEventListener('newcomponent', function (event) {

--- a/graphs/RuntimeMiddleware.fbp
+++ b/graphs/RuntimeMiddleware.fbp
@@ -65,7 +65,7 @@ OpenProjectMode OUT -> IN StorageOpenedAction
 OpenProjectMode ERROR -> IN RuntimeErrorAction
 
 # Send selected edges to runtime
-'graphs' -> KEYS GetEdgeState(ui/GetActionValues)
+'graphs,project' -> KEYS GetEdgeState(ui/GetActionValues)
 Dispatch HANDLE[2] -> IN HasEdgeRuntime(ui/HasActionRuntime)
 HasEdgeRuntime OUT -> IN GetEdgeState
 # If there is no runtime we don't send edges
@@ -73,6 +73,7 @@ HasEdgeRuntime MISSED -> IN Passed
 GetEdgeState STATE -> IN[2] GetClient
 GetClient CLIENT[2] -> CLIENT SendEdges(ui/SendEdges)
 GetEdgeState VALUES[0] -> GRAPHS SendEdges
+GetEdgeState VALUES[1] -> PROJECT SendEdges
 GetEdgeState OUT -> EDGES SendEdges
 SendEdges OUT -> IN ContextEdgesAction
 SendEdges ERROR -> IN RuntimeErrorAction

--- a/spec/e2e/runtime/01_Open.js
+++ b/spec/e2e/runtime/01_Open.js
@@ -170,7 +170,7 @@ describe('Opening a Runtime', () => {
       }));
     it('should show the graph name in the search bar', () => waitForElement('noflo-ui noflo-search h1 span')
       .then((searchTitle) => {
-        chai.expect(searchTitle.innerHTML).to.equal('foo/bar');
+        chai.expect(searchTitle.innerHTML).to.equal('bar');
       }));
     it('should show the graph as "running"', () => waitFor(1000) // Seems this one takes sometimes a while to update
       .then(() => waitForElement('noflo-ui noflo-runtime #runcontrol h2'))

--- a/src/collections.js
+++ b/src/collections.js
@@ -1,7 +1,31 @@
+const { basename } = require('path');
+
 exports.sortByName = (a, b) => {
-  const aName = (a.properties != null ? a.properties.name : undefined) || a.name || a.id || 'Unknown';
-  const bName = (b.properties != null ? b.properties.name : undefined) || b.name || b.id || 'Unknown';
+  const aName = exports.unnamespace(exports.getName(a));
+  const bName = exports.unnamespace(exports.getName(b));
   return aName.localeCompare(bName);
+};
+
+exports.getName = (obj, allowUnknown = true) => {
+  const name = (obj.properties != null ? obj.properties.name : undefined) || obj.name || obj.id;
+  if (!name && allowUnknown) {
+    return 'Unknown';
+  }
+  return name;
+};
+
+exports.unnamespace = (name) => {
+  if (name.indexOf('/') === -1) {
+    return name;
+  }
+  return basename(name);
+};
+
+exports.namespace = (name, namespace) => {
+  if (name.indexOf('/') !== -1) {
+    return name;
+  }
+  return `${namespace}/${name}`;
 };
 
 exports.sortBySeen = (ain, bin) => {
@@ -32,10 +56,8 @@ exports.addToList = (list, entity, sort = exports.sortByName) => {
       found = true;
       return;
     }
-    const existingId = (existing.properties != null ? existing.properties.id : undefined)
-      || existing.id || existing.name;
-    const entityId = (entity.properties != null ? entity.properties.id : undefined)
-      || entity.id || entity.name;
+    const existingId = exports.unnamespace(exports.getName(existing, false));
+    const entityId = exports.unnamespace(exports.getName(entity, false));
     if (existingId === entityId) {
       // id match, replace
       const exists = existing;
@@ -56,9 +78,8 @@ exports.removeFromList = (list, entity) => {
     if (existing === entity) {
       return true;
     }
-    const existingId = (existing.properties != null ? existing.properties.id : undefined)
-      || existing.id;
-    const entityId = (entity.properties != null ? entity.properties.id : undefined) || entity.id;
+    const existingId = exports.unnamespace(exports.getName(existing, false));
+    const entityId = exports.unnamespace(exports.getName(entity, false));
     return (existingId === entityId);
   });
   if (!matched) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,5 +1,18 @@
 const fbpGraph = require('fbp-graph');
 const { findByComponent } = require('./projects');
+const { getName, namespace } = require('./collections');
+
+exports.graphRuntimeIdentifier = (graph, projectNamespace = null) => {
+  if (graph && graph.properties && graph.properties.runtimeName) {
+    // Runtime-supplied identifier, keep stable
+    return graph.properties.runtimeName;
+  }
+  const graphName = getName(graph);
+  if (projectNamespace) {
+    return namespace(graphName, projectNamespace);
+  }
+  return graphName;
+};
 
 const portForLibrary = port => ({
   name: port.id,


### PR DESCRIPTION
There are inconsistencies between how Flowhub uses graph names, and how the runtimes do.

The primary problem is when a graph is loaded by both parties independently (runtime registers network for each graph in the project, Flowhub assumes the networks are there). Then we need to make sure the initial identifiers match.

* When Flowhub gets graph name from runtime (via runtime info), that name should be retained
* When Runtime gets graph name from Flowhub, that name should be retained
* When Flowhub sends graphs, they should always be namespaced
* Saving graph should normalize the name to non-namespaced form in the file
* `@something` and `noflo-` should be removed from the namespace