### PR TITLE
Use custom token for the merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
     - uses: ridedott/merge-me-action@v1.8.61
       with:
         GITHUB_LOGIN: 'dependabot[bot]'
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # We need to use a custom token to trigger a build for the merge
+        # Using the default token doesn't do this.
+        GITHUB_TOKEN: ${{ secrets.GH_MERGE_TOKEN }}
         MERGE_METHOD: MERGE


### PR DESCRIPTION
Turns out using the default `GITHUB_TOKEN` does not trigger a build on merge, which means the automerged PRs (dep updates) don't get deployed to the preview environment

https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token